### PR TITLE
Add  Signal Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ You can see which language is using for app. Curently there are next languages:
 - [GroupMe](https://github.com/dcrousso/GroupMe) - Unofficial GroupMe App. ![JavascriptIcon] ![CSSIcon]
 - [Sidetalk](https://github.com/clint-tseng/sidetalk) - macOS Google Hangouts/XMPP chat client (available in App Store!).
 - [Torchat-Mac](https://github.com/javerous/TorChat-Mac) - TorChat for Mac is a macOS native and unofficial port of torchat. ![ObjectiveCIcon]
+- [Signal Desktop](https://github.com/signalapp/Signal-Desktop) - An Electron app that links with your Signal Android or Signal iOS app. ![JavascriptIcon]
 
 ### Development
 


### PR DESCRIPTION
Include the opensource chatting application Signal Desktop

# Project URLs

https://github.com/signalapp/Signal-Desktop
https://signal.org/download/

# Category

Chat

# Description

Signal is an iOS/Android messaging app for simple private communication with friends. Signal Desktop is an Electron application that links with Signal.

# Checklist

- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Appropriate language icon(s) added if applicable
- [x] Has a commit from less than 2 years ago
- [x] Has a clear README in English