### PR TITLE
Add the chatapp wire

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ You can see which language is using for app. Curently there are next languages:
 - [Sidetalk](https://github.com/clint-tseng/sidetalk) - macOS Google Hangouts/XMPP chat client (available in App Store!).
 - [Torchat-Mac](https://github.com/javerous/TorChat-Mac) - TorChat for Mac is a macOS native and unofficial port of torchat. ![ObjectiveCIcon]
 - [Signal Desktop](https://github.com/signalapp/Signal-Desktop) - An Electron app that links with your Signal Android or Signal iOS app. ![JavascriptIcon]
+- [Wire Desktop](https://github.com/wireapp/wire-desktop) - An standalone Electron app for the chatapp Wire. ![JavascriptIcon]
 
 ### Development
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ You can see which language is using for app. Curently there are next languages:
 - [Sidetalk](https://github.com/clint-tseng/sidetalk) - macOS Google Hangouts/XMPP chat client (available in App Store!).
 - [Torchat-Mac](https://github.com/javerous/TorChat-Mac) - TorChat for Mac is a macOS native and unofficial port of torchat. ![ObjectiveCIcon]
 - [Signal Desktop](https://github.com/signalapp/Signal-Desktop) - An Electron app that links with your Signal Android or Signal iOS app. ![JavascriptIcon]
-- [Wire Desktop](https://github.com/wireapp/wire-desktop) - An standalone Electron app for the chatapp Wire. ![JavascriptIcon]
+- [Wire Desktop](https://github.com/wireapp/wire-desktop) - Standalone Electron app for the chatapp Wire. ![JavascriptIcon]
 
 ### Development
 


### PR DESCRIPTION
## Project URL
https://github.com/wireapp

## Category
Chat

## Description
Add the secure chat app Wire to the list of open source chat apps.
 
## Why it should be included to `Awesome macOS open source applications `
It's a nice secure chat app that is completely open source. (server and clients)

## Checklist
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Appropriate language icon(s) added if applicable
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
