### PR TITLE
Adds Gifcurry.

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ You can see which language is using for app. Curently there are next languages:
 - [ScreenToLayers for macOS](https://github.com/duyquoc/ScreenToLayers) - ScreenToLayers is a macOS application to easily capture your screen as a layered PSD file. ![ObjectiveCIcon] ![CSSIcon]
 - [CaptuocrToy](https://github.com/gragrance/CaptuocrToy) - Tool to capture screenshot and recognize text by online ocr apis. ![SwiftIcon]
 - [Gifski](https://github.com/sindresorhus/gifski-app) - Convert videos to high-quality GIFs. ![SwiftIcon]
+- [Gifcurry](https://github.com/lettier/gifcurry) - Open source video to GIF maker with a graphical interface capable of cropping, adding text, seeking, and trimming. ![Haskell]
 
 
 ### IDE

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ You can see which language is using for app. Curently there are next languages:
 - [ScreenToLayers for macOS](https://github.com/duyquoc/ScreenToLayers) - ScreenToLayers is a macOS application to easily capture your screen as a layered PSD file. ![ObjectiveCIcon] ![CSSIcon]
 - [CaptuocrToy](https://github.com/gragrance/CaptuocrToy) - Tool to capture screenshot and recognize text by online ocr apis. ![SwiftIcon]
 - [Gifski](https://github.com/sindresorhus/gifski-app) - Convert videos to high-quality GIFs. ![SwiftIcon]
-- [Gifcurry](https://github.com/lettier/gifcurry) - Open source video to GIF maker with a graphical interface capable of cropping, adding text, seeking, and trimming. ![Haskell]
+- [Gifcurry](https://github.com/lettier/gifcurry) - Open source video to GIF maker with a graphical interface capable of cropping, adding text, seeking, and trimming. ![HaskellIcon]
 
 
 ### IDE


### PR DESCRIPTION
## Project URL
https://github.com/lettier/gifcurry
https://lettier.github.io/gifcurry

## Category
Graphics

## Description
Adds the open source macOS app Gifcurry made with Haskell, GTK+, and GStreamer.

![Gifcurry](https://i.imgur.com/IQqkxfB.png)
 
## Why it should be included to `Awesome macOS open source applications ` (optional)

[Why do I need Gifcurry?](https://github.com/lettier/gifcurry#what-do-i-need-gifcurry-for)

## Checklist
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Appropriate language icon(s) added if applicable
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English

:+1: 