### PR TITLE
Add SensibleSideButtons

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,7 @@ You can see which in which language an app is written. Curently there are follow
 - [browserosaurus](https://github.com/will-stone/browserosaurus) - macOS tool that prompts you to choose a browser when opening a link.
 - [PB for Desktop](https://github.com/sidneys/pb-for-desktop) - Receive native push notifications on macOS, Windows and Linux. ![JavascriptIcon]
 - [stronghold](https://github.com/alichtman/stronghold) - Easily configure macOS security settings from the terminal. ![PythonIcon]
+- [SensibleSideButtons](https://github.com/archagon/sensible-side-buttons) - A small menu bar utility that lets you use your third-party mouse's side buttons for navigation across a variety of apps. ![CIcon] ![ObjectiveCIcon]
 
 ### VPN & Proxy
 


### PR DESCRIPTION
## Project URL

https://github.com/archagon/sensible-side-buttons

## Category

Utilities

## Description

A small menu bar utility that lets you use your third-party mouse's side buttons for navigation across a variety of apps.
 
## Why it should be included in `Awesome macOS open source applications` (optional)

SensibleSideButtons is one of the only ways to get native, near-universal back/forward behavior for a mouse's side buttons in macOS. Most other approaches involve keyboard shortcuts which don't work very well. (The behavior and technology are described in detail on the [project homepage](http://sensible-side-buttons.archagon.net).)

## Checklist

- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Appropriate language icon(s) added if applicable
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
