### PR TITLE
Added MusaicFM to screensavers

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,7 @@ You can see which in which language an app is written. Curently there are follow
 - [Aerial](https://github.com/JohnCoates/Aerial) - Apple TV Aerial Screensaver for macOS. ![SwiftIcon]
 - [Irvue](https://github.com/leonspok/Irvue-Screensaver) - Screensaver for macOS. ![ObjectiveCIcon]
 - [Image-As-Wallpaper](https://github.com/ved62/Image-As-Wallpaper) - Utility application helps with selection of images for using as desktop wallpaper or in screensaver on Mac computers. ![SwiftIcon]
+- [MusaicFM](https://github.com/docterd/MusaicFM) iTunes Screensaver Clone for Spotify and Last.fm ![ObjectiveCIcon]
 
 ### Sharing Files
 


### PR DESCRIPTION
## Project URL
https://github.com/docterd/MusaicFM

## Category
Screensaver

## Description
Added MusaicFM to screensavers
<!--- Describe your changes in detail -->
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
MusaicFM is a iTunes Screensaver clone for Spotify and Last.fm written in Objective-C.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Appropriate language icon(s) added if applicable
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English