### PR TITLE
Add DisplayMenu

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,7 @@ You can see which in which language an app is written. Curently there are follow
 - [stronghold](https://github.com/alichtman/stronghold) - Easily configure macOS security settings from the terminal. ![PythonIcon]
 - [SensibleSideButtons](https://github.com/archagon/sensible-side-buttons) - A small menu bar utility that lets you use your third-party mouse's side buttons for navigation across a variety of apps. ![CIcon] ![ObjectiveCIcon]
 - [Airpass](https://github.com/alvesjtiago/airpass) - Status bar Mac app to overcome time constrained WiFi networks. ![JavascriptIcon]
+- [DisplayMenu](https://github.com/Kwpolska/DisplayMenu) - A simple (bare-bones) macOS menubar extra to apply display presets. ![SwiftIcon]
 
 ### VPN & Proxy
 


### PR DESCRIPTION
## Project URL
https://github.com/Kwpolska/DisplayMenu

## Category
Utilities

## Description
Added [DisplayMenu](https://github.com/Kwpolska/DisplayMenu), a simple (bare-bones) macOS menubar extra to apply display presets.

## Why it should be included to `Awesome macOS open source applications ` (optional)

Not that many projects do Swift *and* Quartz APIs. It was created because [Apple stole the real display menu from me](https://chriswarrick.com/blog/2017/06/24/apple-broke-the-display-menu-so-i-wrote-my-own/).

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Appropriate language icon(s) added if applicable
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
