### PR TITLE
typo. remove extra "which" from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 List of awesome open source applications for macOS. This list contains a lot of native and cross-platform apps. The main goal of this repository is to find open source and free apps and start contributing.
 
-You can see which in which language an app is written. Curently there are following languages:
+You can see in which language an app is written. Curently there are following languages:
 
 - ![CIcon] - C language.
 - ![CppIcon] - C++ language.


### PR DESCRIPTION
remove the extra "which"

<!--- Provide a general summary of your changes in the Title above -->
There was an extra "which"

## Project URL
<!--- The project URL -->

## Category
<!--- Category in Awesome macOS open source applications where the project will be added -->

## Description
<!--- Describe your changes in detail -->
 
## Why it should be included to `Awesome macOS open source applications ` (optional)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Only one project/change is in this pull request
- [ ] Addition in chronological order (bottom of category)
- [ ] Appropriate language icon(s) added if applicable
- [ ] Has a commit from less than 2 years ago
- [ ] Has a **clear** README in English
