### PR TITLE
Adding "Browser" to the "Contents" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ You can see in which language an app is written. Curently there are following la
 ## Contents
 - [Audio](#audio)
 - [Backup](#backup)
+- [Browser](#browser)
 - [Chat](#chat)
 - [Cryptocurrency](#cryptocurrency)
 - [Development](#development)


### PR DESCRIPTION
## Description
The table of contents section was missing the "Browser" section, and wanted to make it easier to navigate straight to it from the `README.md` file!


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [ ] Addition in chronological order (bottom of category)
- [ ] Appropriate language icon(s) added if applicable
- [ ] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
