### PR TITLE
Append TextMate editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ You can see in which language an app is written. Curently there are following la
 - [Atom](https://github.com/atom/atom) - The hackable text editor. ![JavascriptIcon]
 - [Visual Studio Code](https://github.com/Microsoft/vscode) - Code editor developed by Microsoft. ![TypescriptIcon]
 - [ZeroBraneStudio](https://github.com/pkulchenko/ZeroBraneStudio) - ZeroBrane Studio is a lightweight cross-platform Lua IDE with code completion, syntax highlighting, remote debugger, code analyzer, live coding, and debugging support for various Lua engines. ![LuaIcon]
+- [TextMate](https://github.com/textmate/textmate) - TextMate is a graphical text editor for OS X 10.9+ ![CppIcon] ![ObjectiveCIcon]
 
 ### Images
 


### PR DESCRIPTION
Append TextMate editor

## Project URL
https://github.com/textmate/textmate

## Category
IDE

## Description
TextMate is a graphical text editor for OS X 10.9+
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
This editor is a commercial editor that becomes open-source.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Appropriate language icon(s) added if applicable
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
