### PR TITLE
Add Redis.app

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ You can see in which language an app is written. Curently there are following la
 - [RktMachine](https://github.com/woofwoofinc/rktmachine) - Menu bar macOS app for running rkt in a macOS hypervisor CoreOS VM. ![SwiftIcon]
 - [Regxr](https://github.com/lukakerr/regxr) - Regxr is a minimal, lightweight and beautiful macOS desktop application that allows for easy checking of regular expression pattern matching. ![SwiftIcon]
 - [mongoDB.app](http://gcollazo.github.io/mongodbapp/) - The easiest way to get started with mongoDB on the Mac. ![SwiftIcon]
+- [Redis.app](http://jpadilla.github.io/redisapp/) - The easiest way to get started with Redis on the Mac. ![SwiftIcon]
 
 ### Editors
 

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ You can see in which language an app is written. Curently there are following la
 - [RktMachine](https://github.com/woofwoofinc/rktmachine) - Menu bar macOS app for running rkt in a macOS hypervisor CoreOS VM. ![SwiftIcon]
 - [Regxr](https://github.com/lukakerr/regxr) - Regxr is a minimal, lightweight and beautiful macOS desktop application that allows for easy checking of regular expression pattern matching. ![SwiftIcon]
 - [mongoDB.app](http://gcollazo.github.io/mongodbapp/) - The easiest way to get started with mongoDB on the Mac. ![SwiftIcon]
-- [Redis.app](http://jpadilla.github.io/redisapp/) - The easiest way to get started with Redis on the Mac. ![SwiftIcon]
+- [Redis.app](https://github.com/jpadilla/redisapp) - The easiest way to get started with Redis on the Mac. ![SwiftIcon]
 
 ### Editors
 


### PR DESCRIPTION
## Project URL
http://jpadilla.github.io/redisapp/

## Category
Other

## Description
The easiest way to get started with Redis on the Mac.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
It has a cool update script that makes building and maintaining this kind of app really simple.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Appropriate language icon(s) added if applicable
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
