### PR TITLE
Add React Native Debugger

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ You can see in which language an app is written. Curently there are following la
 - [Feather](https://github.com/lukakerr/feather) - Minimal, lightweight macOS desktop application to check for regular expression pattern matches ![SwiftIcon]
 - [mongoDB.app](http://gcollazo.github.io/mongodbapp/) - The easiest way to get started with mongoDB on the Mac. ![SwiftIcon]
 - [Redis.app](https://github.com/jpadilla/redisapp) - The easiest way to get started with Redis on the Mac. ![SwiftIcon]
+- [React Native Debugger](https://github.com/jhen0409/react-native-debugger) - Desktop app for inspecting your React Native projects. macOS, Linux, and Windows. ![JavascriptIcon]
 
 ### Editors
 


### PR DESCRIPTION
Add React Native Debugger, desktop app that helps in React Native development.

## Project URL
[https://github.com/jhen0409/react-native-debugger](https://github.com/jhen0409/react-native-debugger)

## Category
Development / Other

## Description
This is a standalone app for debugging React Native apps:

* Based on official Remote Debugger and provide more functionally.
* Includes React Inspector from react-devtools-core.
* Includes Redux DevTools, made the same API with redux-devtools-extension.

## Checklist
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Appropriate language icon(s) added if applicable
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
