### PR TITLE
Fix typo for Flycut

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ You can see in which language an app is written. Curently there are following la
 - [ControlPlane](https://github.com/dustinrue/ControlPlane) - Automate running tasks based on where you are or what you do. ![ObjectiveCIcon]
 - [Clocker](https://github.com/abhishekbanthia/Clocker) - macOS app to plan and organize through timezones. ![ObjectiveCIcon]
 - [Toggl Desktop](https://github.com/toggl/toggldesktop/tree/app-store-release-v7.3.319) - Toggl Desktop app for Windows, Mac and Linux. ![CppIcon]
-- [Flycut] (https://github.com/TermiT/flycut) - Clean and simple clipboard manager for developers ![ObjectiveCIcon]
+- [Flycut](https://github.com/TermiT/flycut) - Clean and simple clipboard manager for developers ![ObjectiveCIcon]
 - [Manta](https://github.com/hql287/Manta) - Flexible invoicing desktop app with beautiful & customizable templates. ![JavascriptIcon]
 
 ### Screensaver


### PR DESCRIPTION
The entry for Flycut had an abundant space between name and link causing it to not be rendered as two things: the name and the link separately.

<!--- Provide a general summary of your changes in the Title above -->

## Project URL
<!--- The project URL -->
not applicable
## Category
<!--- Category in Awesome macOS open source applications where the project will be added -->
none - just a bugfix
## Description
<!--- Describe your changes in detail -->
see above.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Appropriate language icon(s) added if applicable
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
