### PR TITLE
Remove duplicate BingPaper pointing to old repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,7 +553,6 @@ You can see in which language an app is written. Curently there are following la
 - [500-mac-wallpaper](https://github.com/cuddlecheek/500-mac-wallpaper) - Simple macOS app for the status bar to automatically download photos from 500px.com to a local folder that can be set as a source of wallpapers. ![SwiftIcon]
 - [Desktop Wallpaper Switcher](https://github.com/VioletGiraffe/desktop-wallpaper-switcher) - Win / Linux / macOS tool for managing and cycling desktop wallpapers. ![CppIcon]
 - [pyDailyChanger](https://github.com/IngoHeimbach/pyDailyChanger) - pyDailyChanger is a program that changes your wallpaper daily. ![PythonIcon]
-- [BingPaper](https://github.com/Majirefy/BingPaper) - Use Bing daily photo as your wallpaper on macOS. ![SwiftIcon]
 
 ### Window Management
 


### PR DESCRIPTION
The removed line pointed to https://github.com/Majirefy/BingPaper, which is no longer maintained. The new source is at https://github.com/pengsrc/BingPaper, which is already entry number 2 on this list.
