### PR TITLE
Add sequel pro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# IntelliJ project files
+.idea/

--- a/README.md
+++ b/README.md
@@ -210,7 +210,8 @@ You can see in which language an app is written. Curently there are following la
 #### Other
 
 - [vegvisir](https://github.com/ant4g0nist/vegvisir) - Browser based GUI for **LLDB** Debugger. ![JavascriptIcon]
-- [macho-browser](https://github.com/dcsch/macho-browser) - Browser for macOS Mach-O binaries.  ![ObjectiveCIcon]
+- [macho-browser](https://github.com/dcsch/macho-browser) - Browser for macOS Mach-O binaries. ![ObjectiveCIcon]
+- [Sequel Pro](https://github.com/sequelpro/sequelpro) - MySQL/MariaDB database management for macOS. ![ObjectiveCIcon] 
 
 #### JSON Parsing
 


### PR DESCRIPTION
- Added Sequel Pro database client.
- Made tiny whitespace change to line above.

## Project URL
https://github.com/sequelpro/sequelpro

## Category
Development/Other

## Description
See bullets above
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
I was surprised it wasn't here already, it's such a slick app, love that it's open source too.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Appropriate language icon(s) added if applicable
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
