### PR TITLE
Add Android tool for Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,7 @@ You can see in which language an app is written. Curently there are following la
 - [The Unarchiver](https://bitbucket.org/kosovan/theunarchiver) - The Unarchiver is an Objective-C application for uncompressing archive files. ![ObjectiveCIcon]
 - [Keka](https://github.com/aonez/Keka) - The macOS file archiver. ![CIcon] ![CppIcon]
 - [Buttercup Desktop](https://github.com/buttercup/buttercup-desktop) - A free, open-source and secure password manager for mac and other platforms. ![JavascriptIcon]
+- [Android tool for Mac](https://github.com/mortenjust/androidtool-mac) - One-click screenshots, video recordings, app installation for iOS and Android ![SwiftIcon]
 
 ### VPN & Proxy
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/mortenjust/androidtool-mac

## Category
Utilities

## Description
One-click screenshots, video recordings, app installation for iOS and Android
 
## Why it should be included in `Awesome macOS open source applications ` (optional)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Appropriate language icon(s) added if applicable
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English