### PR TITLE
Add Maccy clipboard manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ You can see in which language an app is written. Curently there are following la
 - [Flycut](https://github.com/TermiT/flycut) - Clean and simple clipboard manager for developers. ![ObjectiveCIcon]
 - [Manta](https://github.com/hql287/Manta) - Flexible invoicing desktop app with beautiful & customizable templates. ![JavascriptIcon]
 - [Timer](https://github.com/michaelvillar/timer-app) - Simple Timer app for Mac. ![SwiftIcon]
+- [Maccy](https://github.com/p0deje/Maccy) - Lightweight search-as-you-type clipboard manager. ![SwiftIcon]
 
 ### Screensaver
 


### PR DESCRIPTION
## Project URL

[Maccy](https://github.com/p0deje/Maccy)

## Category

Productivity

## Description

Adds [Maccy](https://github.com/p0deje/Maccy), lightweight search-as-you-type clipboard manager for macOS.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)


## Checklist

- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Appropriate language icon(s) added if applicable
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English