### PR TITLE
Add Messenger

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ You can see in which language an app is written. Curently there are following la
 - [Torchat-Mac](https://github.com/javerous/TorChat-Mac) - TorChat for Mac is a macOS native and unofficial port of torchat. ![ObjectiveCIcon]
 - [Signal Desktop](https://github.com/signalapp/Signal-Desktop) - Electron app that links with your Signal Android or Signal iOS app. ![JavascriptIcon]
 - [Wire Desktop](https://github.com/wireapp/wire-desktop) - Standalone Electron app for the chatapp Wire. ![JavascriptIcon]
+- [Messenger](https://github.com/rsms/fb-mac-messenger) - macOS app wrapping Facebook's Messenger for desktop. ![ObjectiveCIcon]
 
 ### Cryptocurrency
 


### PR DESCRIPTION
Close #177 
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/rsms/fb-mac-messenger

## Category
Chat

## Description
⚡️ Mac app wrapping Facebook's Messenger for desktop https://fbmacmessenger.rsms.me/
 
## Why it should be included to `Awesome macOS open source applications ` (optional)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Appropriate language icon(s) added if applicable
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English