### PR TITLE
Add Franz

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ You can see in which language an app is written. Curently there are following la
 - [Signal Desktop](https://github.com/signalapp/Signal-Desktop) - Electron app that links with your Signal Android or Signal iOS app. ![JavascriptIcon]
 - [Wire Desktop](https://github.com/wireapp/wire-desktop) - Standalone Electron app for the chatapp Wire. ![JavascriptIcon]
 - [Messenger](https://github.com/rsms/fb-mac-messenger) - macOS app wrapping Facebook's Messenger for desktop. ![ObjectiveCIcon]
+- [Franz](https://github.com/meetfranz/franz) - Franz is a free messaging app for services like WhatsApp, Slack, Messenger and many more. ![JavascriptIcon]
 
 ### Cryptocurrency
 


### PR DESCRIPTION
Add Franz
Close #105 

## Project URL
https://github.com/meetfranz/franz

## Category
Chat

## Description
Franz is a free messaging app for services like WhatsApp, Slack, Messenger and many more. http://meetfranz.com
 
## Why it should be included to `Awesome macOS open source applications ` (optional)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Appropriate language icon(s) added if applicable
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English