### PR TITLE
add cloudy tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,7 @@ You can see in which language an app is written. Curently there are following la
 - [PSIBar](https://github.com/nikhilsh/PSIBar) - Quickly hacked up PSI OS X status bar app. ![SwiftIcon]
 - [SensibleSideButtons](https://github.com/archagon/sensible-side-buttons) - Small menu bar utility that lets you use your third-party mouse's side buttons for navigation across a variety of apps. ![CIcon] ![ObjectiveCIcon]
 - [Shifty](https://github.com/thompsonate/Shifty) - macOS menu bar app that gives you more control over Night Shift. ![SwiftIcon]
+- [CloudyTabs](https://github.com/josh-/CloudyTabs) - Simple menu bar application that lists your iCloud Tabs and Reading List. ![SwiftIcon]
 
 ### Music
 


### PR DESCRIPTION
# CloudyTabs

Close #49 

## Project URL
https://github.com/josh-/CloudyTabs

## Category
Menubar

## Description
add CloudyTabs from issue [#49](https://github.com/serhii-londar/open-source-mac-os-apps/issues/49)
 
## Why it should be included to `Awesome macOS open source applications ` (optional)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Appropriate language icon(s) added if applicable
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English