### PR TITLE
Add ShazamScrobbler

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ You can see in which language an app is written. Curently there are following la
 - [Sonora](https://github.com/sonoramac/Sonora) - Minimal, beautifully designed music player for OS X. ![ObjectiveCIcon]
 - [AUHost](https://github.com/vgorloff/AUHost) - Application which hosts AudioUnits v3 using AVFoundation API. ![SwiftIcon]
 - [iTunes-Volume-Control](https://github.com/alberti42/iTunes-Volume-Control) - This app allows you to control the iTunes volume using volume up and volume down hotkeys. ![ObjectiveCIcon]
+- [ShazamScrobbler](https://github.com/stephanebruckert/ShazamScrobbler) - Scrobble vinyl, radios, movies to Last.fm. ![ObjectiveCIcon]
 
 ### Backup
 


### PR DESCRIPTION
## Project URL
https://github.com/stephanebruckert/ShazamScrobbler

## Category
Audio

## Description
Scrobble vinyl, radios, movies to Last.fm – ShazamScrobbler was created for people who use Shazam to identify songs played around their Mac and would like to keep an updated playback history using Last.fm's scrobbling service.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
For Last.fm and Shazam lovers – only available on Mac

## Checklist
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Appropriate language icon(s) added if applicable
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
