### PR TITLE
Add WhatsAppBar

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ You can see in which language an app is written. Curently there are following la
 - [Wire Desktop](https://github.com/wireapp/wire-desktop) - Standalone Electron app for the chatapp Wire. ![JavascriptIcon]
 - [Messenger](https://github.com/rsms/fb-mac-messenger) - macOS app wrapping Facebook's Messenger for desktop. ![ObjectiveCIcon]
 - [Franz](https://github.com/meetfranz/franz) - Franz is a free messaging app for services like WhatsApp, Slack, Messenger and many more. ![JavascriptIcon]
+- [WhatsAppBar](https://github.com/aldychris/WhatsAppBar) - Send WhatsApp message from menu bar. ![SwiftIcon]
 
 ### Cryptocurrency
 


### PR DESCRIPTION
Add WhatsAppBar Menubar App

## Project URL
https://github.com/aldychr/WhatsAppBar

## Category
Chat

## Description
WhatsAppBar helps you to send WhatsApp messages to someone who is not on your contact list. You don't need to save the number first to start chatting.

## Checklist
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Appropriate language icon(s) added if applicable
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
