### PR TITLE
Add macOrganizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@ You can see in which language an app is written. Curently there are following la
 - [Maccy](https://github.com/p0deje/Maccy) - Lightweight search-as-you-type clipboard manager. ![SwiftIcon]
 - [Cerebro](https://github.com/KELiON/cerebro) - Cross-platform launcher app. ![JavascriptIcon]
 - [Quickwords](https://github.com/quickwords/quickwords) - Write anything in a matter of seconds. Create snippets that can substitute text, execute tedious tasks and more. ![JavascriptIcon]![CSSIcon]
+- [macOrganizer](https://github.com/shubhambatra3019/macOrganizer) - macOS app for organizing files or removing unnecessary files. ![SwiftIcon]
 
 ### Screensaver
 


### PR DESCRIPTION
Add macOrganizer app

## Project URL

https://github.com/shubhambatra3019/macOrganizer

## Category
Productivity

## Description
macOrganizer is a macOS app that helps you organize files or remove unnecessary files.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Appropriate language icon(s) added if applicable
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
