### PR TITLE
add Riot.im (collaboration client for the Matrix.org protocol)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ You can see in which language an app is written. Curently there are following la
 - [Messenger](https://github.com/rsms/fb-mac-messenger) - macOS app wrapping Facebook's Messenger for desktop. ![ObjectiveCIcon]
 - [Franz](https://github.com/meetfranz/franz) - Franz is a free messaging app for services like WhatsApp, Slack, Messenger and many more. ![JavascriptIcon]
 - [WhatsAppBar](https://github.com/aldychris/WhatsAppBar) - Send WhatsApp message from menu bar. ![SwiftIcon]
+- [Riot.im](https://github.com/vector-im/riot-web) - Riot.im is a collaboration app (currently Electron) for the [Matrix](https://matrix.org) protocol. ![JavascriptIcon]
 
 ### Cryptocurrency
 


### PR DESCRIPTION
## Project URL
https://riot.im
https://github.com/vector-im/riot-web

## Category
Chat

## Description
Adds Riot.im to the Chat category.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
Apache licensed Electron client for decentralised, end-to-end encrypted communication via the Matrix protocol.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Appropriate language icon(s) added if applicable
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
