### PR TITLE
Fix Link issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ You can see in which language an app is written. Curently there are following la
 - [Messenger](https://github.com/rsms/fb-mac-messenger) - macOS app wrapping Facebook's Messenger for desktop. ![ObjectiveCIcon]
 - [Franz](https://github.com/meetfranz/franz) - Franz is a free messaging app for services like WhatsApp, Slack, Messenger and many more. ![JavascriptIcon]
 - [WhatsAppBar](https://github.com/aldychris/WhatsAppBar) - Send WhatsApp message from menu bar. ![SwiftIcon]
-- [Riot.im](https://github.com/vector-im/riot-web) - Riot.im is a collaboration app (currently Electron) for the [Matrix](https://matrix.org) protocol. ![JavascriptIcon]
+- [Riot.im](https://github.com/vector-im/riot-web) - Riot.im is a collaboration app (currently Electron) for the [Matrix](https://matrix.org/blog/home/) protocol. ![JavascriptIcon]
 
 ### Cryptocurrency
 


### PR DESCRIPTION
https://matrix.org redirects to https://matrix.org/blog/home