### PR TITLE
Add spotify-cli-mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ You can see in which language an app is written. Currently there are following l
 - [ChordDetector](https://github.com/cemolcay/ChordDetector) - Tiny menu bar app that listens iTunes and Spotify to detect chords of songs! ![SwiftIcon]
 - [Carol](https://github.com/AnaghSharma/Carol) - A minimal and beautiful lyrics app that stays in the menu bar of macOS. ![CSharpIcon]
 - [YouTube-Music](https://github.com/steve228uk/YouTube-Music) - macOS wrapper for music.youtube.com. ![SwiftIcon]
+- [Spotify-Cli-Mac](https://github.com/ersel/spotify-cli-mac) - Control Spotify without leaving your terminal. :notes: ![JavascriptIcon]
 
 ### News
 


### PR DESCRIPTION
## Project URL
https://github.com/ersel/spotify-cli-mac

## Category
Music

## Description
 Lets you control spotify from your terminal. You can also set genius integration to display lyrics.

## Why it should be included to `Awesome macOS open source applications ` (optional)
Because Mac Os users likes to 👂 🎶 

## Checklist
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Appropriate language icon(s) added if applicable
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
