### PR TITLE
Add Noto plain text editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ You can see in which language an app is written. Currently there are following l
 - [MacVim](https://github.com/macvim-dev/macvim) - Text editor for macOS. ![CIcon]
 - [TextMate](https://github.com/textmate/textmate) - TextMate is a graphical text editor for macOS. ![ObjectiveCIcon]
 - [VimR](https://github.com/qvacua/vimr) - Refined Neovim experience for macOS. ![SwiftIcon]
+- [Noto](https://github.com/brunophilipe/noto) - Plain text editor for macOS with customizable themes. ![SwiftIcon]
 
 #### Markdown
 - [MacDown](https://github.com/MacDownApp/macdown) - Open source Markdown editor for macOS. ![ObjectiveCIcon]


### PR DESCRIPTION
Add my text editor Noto.

## Project URL
https://github.com/brunophilipe/Noto

## Category
Editors/Text

## Description
A simple plain text editor for macOS with customisable UI themes.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
Because it is awesome 😄

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Appropriate language icon(s) added if applicable
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
