### PR TITLE
Add ci2go under new Development -> CI/CD section

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ You can see in which language an app is written. Currently there are following l
 	- [Web development](#web-development)
 	- [Other](#other)
 	- [JSON Parsing](#json-parsing)
+	- [CI/CD](#ci--cd)
 - [Downloader](#downloader)
 - [Editors](#editors)
 	- [JSON](#json)
@@ -247,6 +248,10 @@ You can see in which language an app is written. Currently there are following l
 - [JSON Mapper](https://github.com/AppCraft-LLC/json-mapper) - Simple macOS app to generate Swift Object Mapper classes from JSON. ![SwiftIcon]
 - [JSONExport](https://github.com/Ahmed-Ali/JSONExport) - Desktop application for macOS which enables you to export JSON objects as model classes with their associated constructors, utility methods, setters and getters in your favorite language. ![SwiftIcon]
 - [j2s](https://github.com/zadr/j2s) - macOS app to convert JSON objects into Swift structs (currently targets Swift 4 and Codable). ![SwiftIcon]
+
+#### CI/CD
+
+- [ci2go](https://github.com/ngs/ci2go) - CircleCI client. ![SwiftIcon]
 
 ### Downloader
 


### PR DESCRIPTION
## Project URL
https://github.com/ngs/ci2go

## Category
Development -> CI/CD

## Description
Add ci2go, macOS client for CircleCI
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
Because it's awesome. It works even for Apple Watch.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Appropriate language icon(s) added if applicable
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
