### PR TITLE
Reorder alphabetically - icons, contents, audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,18 +20,18 @@ You can see in which language an app is written. Currently there are following l
 
 - ![CIcon] - C language.
 - ![CppIcon] - C++ language.
-- ![JavascriptIcon] - JavaScript language.
-- ![ObjectiveCIcon] - Objective-C language.
-- ![SwiftIcon] - Swift language.
+- ![CSharpIcon] - C# language.
 - ![CoffeescriptIcon] - CoffeeScript language.
-- ![TypescriptIcon] - TypeScript language.
-- ![PythonIcon] - Python language.
 - ![CSSIcon] - CSS language.
+- ![HaskellIcon] - Haskell language.
+- ![JavascriptIcon] - JavaScript language.
+- ![LuaIcon] - Lua language.
+- ![ObjectiveCIcon] - Objective-C language.
+- ![PythonIcon] - Python language.
 - ![RubyIcon] - Ruby language.
 - ![RustIcon] - Rust language.
-- ![LuaIcon] - Lua language.
-- ![HaskellIcon] - Haskell language.
-- ![CSharpIcon] - C# language.
+- ![SwiftIcon] - Swift language.
+- ![TypescriptIcon] - TypeScript language.
 
 ## Contents
 - [Audio](#audio)
@@ -43,15 +43,15 @@ You can see in which language an app is written. Currently there are following l
 - [Development](#development)
 	- [Git](#git)
 	- [iOS / macOS](#ios--macos)
+	- [JSON Parsing](#json-parsing)
 	- [Web development](#web-development)
 	- [Other](#other)
-	- [JSON Parsing](#json-parsing)
 - [Downloader](#downloader)
 - [Editors](#editors)
 	- [JSON](#json)
+	- [Markdown](#markdown)
 	- [TeX](#tex)
 	- [Text](#text)
-	- [Markdown](#markdown)
 - [Extensions](#extensions)
 - [Finder](#finder)
 - [Games](#games)
@@ -62,8 +62,8 @@ You can see in which language an app is written. Currently there are following l
 - [Mail](#mail)
 - [Menubar](#menubar)
 - [Music](#music)
-- [Notes](#notes)
 - [News](#news)
+- [Notes](#notes)
 - [Podcast](#podcast)
 - [Productivity](#productivity)
 - [Screensaver](#screensaver)
@@ -83,29 +83,29 @@ You can see in which language an app is written. Currently there are following l
 
 ### Audio
 
-- [Background Music](https://github.com/kyleneideck/BackgroundMusic) - Background Music, a macOS audio utility: automatically pause your music, set individual apps' volumes and record system audio. ![CppIcon]
-- [Cog](https://github.com/kode54/Cog) - Free and Open Source Audio Player for macOS. ![CIcon]
-- [[Un]MuteMic](https://github.com/CocoaHeadsBrasil/MuteUnmuteMic) - macOS app to mute & unmute the input volume of your microphone. Perfect for podcasters. ![CIcon] ![ObjectiveCIcon]
-- [Tickeys](https://github.com/yingDev/Tickeys) - Instant audio feedback for typing. macOS version. ![RustIcon]
-- [Mous Player](https://github.com/bsdelf/mous) - Simple yet powerful audio player for BSD/Linux/macOS. ![CppIcon]
-- [SpotSpot](https://github.com/will-stone/SpotSpot) - Spotify mini-player for macOS. ![JavascriptIcon]
-- [SBPlayer](https://github.com/shibiao/SBPlayerClient) - SBPlayer is a beautiful and powerful media player base on VLCKit. ![ObjectiveCIcon]
+- [AUHost](https://github.com/vgorloff/AUHost) - Application which hosts AudioUnits v3 using AVFoundation API. ![SwiftIcon]
 - [Aural Player](https://github.com/maculateConception/aural-player) - Aural Player is a free and open source audio player application for the macOS platform. Inspired by the classic Winamp player for Windows, it is designed to be to-the-point and easy to use. ![SwiftIcon]
-- [Suohai](https://github.com/Sunnyyoung/Suohai) - Audio input/output source lock for macOS. ![SwiftIcon]
-- [LocalRadio](https://github.com/dsward2/LocalRadio) - LocalRadio is software for listening to "Software-Defined Radio" on your Mac and mobile devices. ![ObjectiveCIcon]
-- [fre:ac](https://github.com/enzo1982/freac) - The fre:ac audio converter project. ![CppIcon]
+- [Background Music](https://github.com/kyleneideck/BackgroundMusic) - Background Music, a macOS audio utility: automatically pause your music, set individual apps' volumes and record system audio. ![CppIcon]
+- [[Un]MuteMic](https://github.com/CocoaHeadsBrasil/MuteUnmuteMic) - macOS app to mute & unmute the input volume of your microphone. Perfect for podcasters. ![CIcon] ![ObjectiveCIcon]
 - [CAM](https://github.com/hanayik/CAM) - macOS camera recording using ffmpeg ![JavascriptIcon]
-- [SpotMenu](https://github.com/kmikiy/SpotMenu) - Spotify and iTunes in your menu bar. ![SwiftIcon] ![ObjectiveCIcon]
+- [Cog](https://github.com/kode54/Cog) - Free and Open Source Audio Player for macOS. ![CIcon]
+- [fre:ac](https://github.com/enzo1982/freac) - The fre:ac audio converter project. ![CppIcon]
+- [jmc](https://github.com/jcm93/jmc) - jmc - new macOS media organizer. ![SwiftIcon]
+- [iTunes-Volume-Control](https://github.com/alberti42/iTunes-Volume-Control) - This app allows you to control the iTunes volume using volume up and volume down hotkeys. ![ObjectiveCIcon]
+- [LocalRadio](https://github.com/dsward2/LocalRadio) - LocalRadio is software for listening to "Software-Defined Radio" on your Mac and mobile devices. ![ObjectiveCIcon]
 - [Lyricism](https://github.com/lyc2345/Lyricism) - macOS app to show you lyric what currently iTunes or Spotify is playing.
-- [waveSDR](https://github.com/getoffmyhack/waveSDR) - macOS native desktop Software Defined Radio application using the RTL-SDR USB device.
 - [Lyrics](https://github.com/MichaelRow/Lyrics) - Swift-based iTunes plug-in to display lyrics on the desktop. ![SwiftIcon]
 - [LyricsX](https://github.com/ddddxxx/LyricsX) - Lyrics for iTunes, Spotify and Vox. ![SwiftIcon]
-- [jmc](https://github.com/jcm93/jmc) - jmc - new macOS media organizer. ![SwiftIcon]
+- [Mous Player](https://github.com/bsdelf/mous) - Simple yet powerful audio player for BSD/Linux/macOS. ![CppIcon]
 - [Muse](https://github.com/xzzz9097/Muse) - Open source Spotify controller with TouchBar support.
-- [Sonora](https://github.com/sonoramac/Sonora) - Minimal, beautifully designed music player for OS X. ![ObjectiveCIcon]
-- [AUHost](https://github.com/vgorloff/AUHost) - Application which hosts AudioUnits v3 using AVFoundation API. ![SwiftIcon]
-- [iTunes-Volume-Control](https://github.com/alberti42/iTunes-Volume-Control) - This app allows you to control the iTunes volume using volume up and volume down hotkeys. ![ObjectiveCIcon]
+- [SBPlayer](https://github.com/shibiao/SBPlayerClient) - SBPlayer is a beautiful and powerful media player base on VLCKit. ![ObjectiveCIcon]
 - [ShazamScrobbler](https://github.com/stephanebruckert/ShazamScrobbler) - Scrobble vinyl, radios, movies to Last.fm. ![ObjectiveCIcon]
+- [Sonora](https://github.com/sonoramac/Sonora) - Minimal, beautifully designed music player for OS X. ![ObjectiveCIcon]
+- [SpotMenu](https://github.com/kmikiy/SpotMenu) - Spotify and iTunes in your menu bar. ![SwiftIcon] ![ObjectiveCIcon]
+- [SpotSpot](https://github.com/will-stone/SpotSpot) - Spotify mini-player for macOS. ![JavascriptIcon]
+- [Suohai](https://github.com/Sunnyyoung/Suohai) - Audio input/output source lock for macOS. ![SwiftIcon]
+- [Tickeys](https://github.com/yingDev/Tickeys) - Instant audio feedback for typing. macOS version. ![RustIcon]
+- [waveSDR](https://github.com/getoffmyhack/waveSDR) - macOS native desktop Software Defined Radio application using the RTL-SDR USB device.
 
 ### Backup
 


### PR DESCRIPTION
Reordering items alphabetically.

The icons and contents section both turned out to have edge cases.

* The ordering of the "C" letter icons is just my best guess.  "Should be ok". :smile:
* Under the Development heading of the Contents, "Other" is manually in the last spot on purpose.  That's just because it's traditional to put the exception/catch-all ("Other" or "Misc") at the end of lists. :smile: