### PR TITLE
Remove Keka, as it's not really Open Source

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,7 +533,6 @@ You can see in which language an app is written. Currently there are following l
 - [Kap](https://github.com/wulkano/kap) - Open source screen recorder built with web technology. ![JavascriptIcon]
 - [KeePassXC](https://github.com/keepassxreboot/keepassxc) - Cross-platform community-driven port of the Windows application "Keepass Password Safe" ![CppIcon]
 - [KeeWeb](https://github.com/keeweb/keeweb) - Free cross-platform password manager compatible with KeePass. ![JavascriptIcon]
-- [Keka](https://github.com/aonez/Keka) - The macOS file archiver. ![CIcon] ![CppIcon]
 - [Life-Calendar](https://github.com/wvdk/Life-Calendar) - Life Calendar. ![SwiftIcon]
 - [MacPass](https://github.com/MacPass/MacPass) - Native OS X KeePass client. ![ObjectiveCIcon]
 - [Maria](https://github.com/shincurry/Maria) - macOS native app/widget for aria2 download tool. ![SwiftIcon]


### PR DESCRIPTION
This removes Keka, as it's source code is not really in their GitHub repo.

They have stated rough intentions to add it in future if they can solve some problems.

If/when those problems are solved, that's probably the time to consider adding it back. :smile:

