### PR TITLE
Change markr to twig (new project)

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ You can see in which language an app is written. Currently there are following l
 
 - [MacDown](https://github.com/MacDownApp/macdown) - Open source Markdown editor for macOS. ![ObjectiveCIcon]
 - [Mark Text](https://github.com/marktext/marktext/) - Realtime preview markdown editor for macOS Windows and Linux. ![JavascriptIcon]
-- [Markr](https://github.com/lukakerr/markr) - Minimalistic markdown editor for macOS with live preview. ![SwiftIcon]
+- [Twig](https://github.com/lukakerr/twig) - A modern MacOS markdown editor. ![SwiftIcon]
 
 #### TeX
 


### PR DESCRIPTION
Changing Markr to Twig (the successor to Markr)

## Project URL
https://github.com/lukakerr/twig

## Category
Editors -> Markdown

## Description
Changed the name and URL of Markr to Twig
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
Already included, just switched projects

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in alphabetical order
- [x] Appropriate language icon(s) added if applicable
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
