### PR TITLE
adding pianobar

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ You can see in which language an app is written. Currently there are following l
 - [LyricsX](https://github.com/ddddxxx/LyricsX) - Lyrics for iTunes, Spotify and Vox. ![SwiftIcon]
 - [Mous Player](https://github.com/bsdelf/mous) - Simple yet powerful audio player for BSD/Linux/macOS. ![CppIcon]
 - [Muse](https://github.com/xzzz9097/Muse) - Open source Spotify controller with TouchBar support.
+- [pianobar](https://github.com/PromyLOPh/pianobar) - Console-based pandora.com player. ![CIcon]
 - [SBPlayer](https://github.com/shibiao/SBPlayerClient) - SBPlayer is a beautiful and powerful media player base on VLCKit. ![ObjectiveCIcon]
 - [ShazamScrobbler](https://github.com/stephanebruckert/ShazamScrobbler) - Scrobble vinyl, radios, movies to Last.fm. ![ObjectiveCIcon]
 - [Sonora](https://github.com/sonoramac/Sonora) - Minimal, beautifully designed music player for OS X. ![ObjectiveCIcon]


### PR DESCRIPTION
added pianobar console player for pandora.com

## Project URL
https://github.com/PromyLOPh/pianobar/tree/master/src

## Category
Audio

## Description
added pianobar console player for pandora.com
 
## Why it should be included to `Awesome macOS open source applications ` (optional)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in alphabetical order
- [x] Appropriate language icon(s) added if applicable
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English