### PR TITLE
Add FiScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ You can see in which language an app is written. Currently there are following l
 
 - [Clipy](https://github.com/Clipy/Clipy) - Clipy is a Clipboard extension app for macOS. ![SwiftIcon]
 - [Finder Go](https://github.com/onmyway133/FinderGo) - macOS app and Finder Sync Extension to open Terminal, iTerm, Hyper from Finder. ![SwiftIcon]
+- [FiScript](https://github.com/Mortennn/FiScript) - Execute custom scripts from the MacOS context menu (CTRL+click) in Finder. ![SwiftIcon]
 - [OpenInCode](https://github.com/sozercan/OpenInCode) - Finder toolbar app to open current folder in Visual Studio Code. ![ObjectiveCIcon]
 
 ### Games


### PR DESCRIPTION
## Project URL
https://github.com/Mortennn/FiScript

## Category
Finder

## Description
Added FiScript which lets you execute custom scripts from the MacOS context menu (CTRL+click) in Finder. 
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
It is an unique application which i think people will enjoy.

## Checklist
- [x] Only one project/change is in this pull request
- [x] Addition in alphabetical order
- [x] Appropriate language icon(s) added if applicable
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English