### PR TITLE
Add OpenShot

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,6 +578,7 @@ You can see in which language an app is written. Currently there are following l
 - [Gifted](https://github.com/vdel26/gifted) - Turn any short video into an animated GIF quickly and easily. ![objective_c_icon]
 - [HandBrake](https://github.com/HandBrake/HandBrake) - HandBrake is a video transcoder available for Linux, Mac, and Windows. ![c_icon]
 - [MenuTube](https://github.com/edanchenkov/MenuTube) - Catch YouTube into your macOS menu bar! ![javascript_icon]
+- [OpenShot](https://github.com/OpenShot/openshot-qt) - Easy to use, quick to learn, and surprisingly powerful video editor. ![python_icon]
 - [QuickLook Video](https://github.com/Marginal/QLVideo) - This package allows macOS Finder to display thumbnails, static QuickLook previews, cover art and metadata for most types of video files. ![objective_c_icon]
 - [Subler](https://bitbucket.org/galad87/subler/overview) - Subler is an macOS app created to mux and tag mp4 files. ![objective_c_icon]
 - [Vid Quiz Creator](https://github.com/sahil-a/vidquizcreator) - macOS application to insert quizzes within video playback and play those videos to receiving devices using the LISNR API. ![swift_icon]


### PR DESCRIPTION
This repo is the primary development home for OpenShot Video Editor (version 2+), a PyQt video editing application which utilizes the powerful libopenshot C++ library.

Close #259 

## Project URL
https://github.com/OpenShot/openshot-qt

## Category
Video

## Description
Easy to use, quick to learn, and surprisingly powerful video editor.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in alphabetical order
- [x] Appropriate language icon(s) added if applicable
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English