### PR TITLE
Add Seaglass

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ You can see in which language an app is written. Currently there are following l
 - [Google Allo for Desktop](https://github.com/kelyvin/Google-Allo-For-Desktop) - Native macOS & Windows desktop app for Google Allo.
 - [GroupMe](https://github.com/dcrousso/GroupMe) - Unofficial GroupMe App. ![javascript_icon] ![css_icon]
 - [Riot.im](https://github.com/vector-im/riot-web) - Riot.im is a collaboration app (currently Electron) for the [Matrix](https://matrix.org/blog/home/) protocol. ![javascript_icon]
+- [Seaglass](https://github.com/neilalexander/seaglass) - A truly native [Matrix](https://matrix.org/blog/home/) client for macOS. ![swift_icon]
 - [Signal Desktop](https://github.com/signalapp/Signal-Desktop) - Electron app that links with your Signal Android or Signal iOS app. ![javascript_icon]
 - [Telegram](https://github.com/overtake/TelegramSwift) - Source code of Telegram for macOS on Swift. ![swift_icon]
 - [Telegram [Deprecated]](https://github.com/overtake/telegram) - Source code of deprecated Telegram for macOS version. ![objective_c_icon]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/neilalexander/seaglass

## Category
Chat

## Description
Seaglass is a native Matrix client for macOS
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
The only other matrix client on this list is an electron app.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] Only one project/change is in this pull request
- [X] Addition in alphabetical order
- [X] Appropriate language icon(s) added if applicable
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English