### PR TITLE
Added Android Messenger Mac to chat section

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ You can see in which language an app is written. Currently there are following l
 
 ### Chat
 
+- [Android Messenger Mac](https://github.com/jake-101/android-messenger-mac) - 
+Mac app wrapper around Google's stand-alone Android Messenger. ![javascript_icon]
 - [ChitChat](https://github.com/stonesam92/ChitChat) - Native Mac app wrapper for WhatsApp Web. ![objective_c_icon]
 - [Electronic WeChat](https://github.com/geeeeeeeeek/electronic-wechat) - Better WeChat on macOS and Linux. ![javascript_icon]
 - [Franz](https://github.com/meetfranz/franz) - Franz is messaging application for services like WhatsApp, Slack, Messenger and many more. ![javascript_icon]


### PR DESCRIPTION

## Project URL
https://github.com/jake-101/android-messenger-mac

## Category
Chat

## Description
Mac app wrapper around Google's stand-alone Android Messenger.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
I haven't seen any other wrappers for Google's SMS web app for Mac. It has been very useful for me so I thought I'd share it with the community.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] Only one project/change is in this pull request
- [ x] Addition in alphabetical order
- [ x] Appropriate language icon(s) added if applicable
- [ x] Has a commit from less than 2 years ago
- [ x] Has a **clear** README in English
