### PR TITLE
Add Thyme

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,7 @@ Mac app wrapper around Google's stand-alone Android Messenger. ![javascript_icon
 - [SelfControl](https://github.com/SelfControlApp/selfcontrol) - macOS app to block your own access to distracting websites etc for a predetermined period of time. It can not be undone by the app or by a restart – you must wait for the timer to run out. ![objective_c_icon]
 - [status-bar-todo](https://github.com/Onix-Systems/osx-status-bar-todo) - Simple macOS app to keep TODO-list in status bar. ![swift_icon]
 - [stretchly](https://github.com/hovancik/stretchly) - Cross-platform electron app that reminds you to take breaks when working with computer. ![javascript_icon]
+- [Thyme](https://github.com/joaomoreno/thyme) - The task timer for OS X. ![objective_c_icon]
 - [Timer](https://github.com/michaelvillar/timer-app) - Simple Timer app for Mac. ![swift_icon]
 - [Toggl Desktop](https://github.com/toggl/toggldesktop/tree/app-store-release-v7.3.319) - Toggl Desktop app for Windows, Mac and Linux. ![cpp_icon]
 - [TrelloApp](https://github.com/jlong/TrelloApp) - Unofficial wrapper application for Trello.com written in Swift. This is almost a "Hello World" for a site specific browser. ![swift_icon]


### PR DESCRIPTION
## Project URL
https://github.com/joaomoreno/thyme

## Category
Productivity

## Description
Add a task timer
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
Thyme is a timer for OS X. It's as simple as that.

## Checklist
- [ ] Only one project/change is in this pull request
- [ ] Addition in alphabetical order
- [ ] Appropriate language icon(s) added if applicable
- [ ] Has a commit from less than 2 years ago
- [ ] Has a **clear** README in English
