### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,7 +469,7 @@ Mac app wrapper around Google's stand-alone Android Messenger. ![javascript_icon
 - [Timer](https://github.com/michaelvillar/timer-app) - Simple Timer app for Mac. ![swift_icon]
 - [Toggl Desktop](https://github.com/toggl/toggldesktop/tree/app-store-release-v7.3.319) - Toggl Desktop app for Windows, Mac and Linux. ![cpp_icon]
 - [TrelloApp](https://github.com/jlong/TrelloApp) - Unofficial wrapper application for Trello.com written in Swift. This is almost a "Hello World" for a site specific browser. ![swift_icon]
-- [Watson](http://tailordev.github.io/Watson/) - A CLI application for time tracking. ![python_icon] 
+- [Watson](https://github.com/TailorDev/Watson) - A CLI application for time tracking. ![python_icon] 
 - [Whale](https://github.com/1000ch/whale) - Unofficial Trello app. ![javascript_icon]
 - [Yomu](https://github.com/sendyhalim/Yomu) - Manga reader app for macOS. ![swift_icon]
 

--- a/README.md
+++ b/README.md
@@ -469,6 +469,7 @@ Mac app wrapper around Google's stand-alone Android Messenger. ![javascript_icon
 - [Timer](https://github.com/michaelvillar/timer-app) - Simple Timer app for Mac. ![swift_icon]
 - [Toggl Desktop](https://github.com/toggl/toggldesktop/tree/app-store-release-v7.3.319) - Toggl Desktop app for Windows, Mac and Linux. ![cpp_icon]
 - [TrelloApp](https://github.com/jlong/TrelloApp) - Unofficial wrapper application for Trello.com written in Swift. This is almost a "Hello World" for a site specific browser. ![swift_icon]
+- [Watson](http://tailordev.github.io/Watson/) - A CLI application for time tracking. ![python_icon] 
 - [Whale](https://github.com/1000ch/whale) - Unofficial Trello app. ![javascript_icon]
 - [Yomu](https://github.com/sendyhalim/Yomu) - Manga reader app for macOS. ![swift_icon]
 


### PR DESCRIPTION
Add time tracking application Watson to the Productivity section.

<!--- Provide a general summary of your changes in the Title above -->

## Project URL
http://tailordev.github.io/Watson/

## Category
Productivity

## Description
Watson is a pretty cool time tracking application you can drive from the command-line. I've used it to replace Harvest for time tracking projects.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] Only one project/change is in this pull request
- [ x] Addition in alphabetical order
- [ x] Appropriate language icon(s) added if applicable
- [ x] Has a commit from less than 2 years ago
- [ x] Has a **clear** README in English
