### PR TITLE
add clashX

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,6 +586,7 @@ Mac app wrapper around Google's stand-alone Android Messenger. ![javascript_icon
 
 ### VPN & Proxy
 
+- [clashX](https://github.com/yichengchen/clashX) - A rule based custom proxy with GUI for Mac base on clash. ![swift_icon]
 - [rvc-mac](https://github.com/riboseinc/rvc-mac) - Ribose VPN Client macOS Menu App. ![swift_icon]
 - [ShadowsocksX-NG](https://github.com/shadowsocks/ShadowsocksX-NG) - Next Generation of ShadowsocksX. ![swift_icon]
 - [Specht](https://github.com/zhuhaow/Specht) - Rule-based proxy app built with Network Extension for macOS. ![swift_icon]


### PR DESCRIPTION
add clashX

## Project URL
https://github.com/yichengchen/clashX

## Category
VPN & Proxy

## Description
A rule based custom proxy with GUI for Mac base on clash.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in alphabetical order
- [x] Appropriate language icon(s) added if applicable
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
