### PR TITLE
Add Emacs text editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ Mac app wrapper around Google's stand-alone Android Messenger. ![javascript_icon
 #### Text
 
 - [CotEditor](https://github.com/coteditor/CotEditor) - Lightweight Plain-Text Editor for macOS. ![swift_icon]
-- [Emacs](https://git.savannah.gnu.org/git/emacs.git) - An extensible, customizable, free/libre text editor — and more.
+- [Emacs](https://git.savannah.gnu.org/cgit/emacs.git) - An extensible, customizable, free/libre text editor — and more.
 - [MacVim](https://github.com/macvim-dev/macvim) - Text editor for macOS. ![c_icon]
 - [Noto](https://github.com/brunophilipe/noto) - Plain text editor for macOS with customizable themes. ![swift_icon]
 - [TextMate](https://github.com/textmate/textmate) - TextMate is a graphical text editor for macOS. ![objective_c_icon]

--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ Mac app wrapper around Google's stand-alone Android Messenger. ![javascript_icon
 #### Text
 
 - [CotEditor](https://github.com/coteditor/CotEditor) - Lightweight Plain-Text Editor for macOS. ![swift_icon]
+- [Emacs](https://git.savannah.gnu.org/git/emacs.git) - An extensible, customizable, free/libre text editor — and more.
 - [MacVim](https://github.com/macvim-dev/macvim) - Text editor for macOS. ![c_icon]
 - [Noto](https://github.com/brunophilipe/noto) - Plain text editor for macOS with customizable themes. ![swift_icon]
 - [TextMate](https://github.com/textmate/textmate) - TextMate is a graphical text editor for macOS. ![objective_c_icon]


### PR DESCRIPTION
Solves #218 

No image icon was added because Emacs is written in Emacs Lisp

<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://www.gnu.org/software/emacs/ but source hosted at https://git.savannah.gnu.org/cgit/emacs.git
## Category
<!--- Category in Awesome macOS open source applications where the project will be added -->
Editors/Text
## Description
<!--- Describe your changes in detail -->
 
## Why it should be included to `Awesome macOS open source applications ` (optional)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] Only one project/change is in this pull request
- [x ] Addition in alphabetical order
- [ ] Appropriate language icon(s) added if applicable
- [ ] Screenshots(s) added if any
- [x ] Has a commit from less than 2 years ago
- [ x] Has a **clear** README in English