### PR TITLE
Add DevDocs for macOS

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -3140,6 +3140,18 @@
       "category" : "other"
     },
     {
+      "repo_url" : "https://github.com/dteoh/devdocs-macos",
+      "title" : "DevDocs for macOS",
+      "screenshots" : [
+        "https://raw.githubusercontent.com/dteoh/devdocs-macos/master/img/screenshot.png"
+      ],
+      "short_description" : "An unofficial DevDocs API documentation viewer.",
+      "languages" : [
+        "swift"
+      ],
+      "category" : "other"
+    },
+    {
       "repo_url" : "https://github.com/2ndalpha/gasmask",
       "title" : "Gas Mask",
       "screenshots" : [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL

https://github.com/dteoh/devdocs-macos

## Category

Other

## Description

Added a link to DevDocs for macOS app.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)

This app lets developers use [DevDocs](https://devdocs.io) as a standalone tool. It is a FOSS alternative to Dash.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in alphabetical order
- [x] Appropriate language icon(s) added if applicable
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
