### PR TITLE
add Robo 3T (formerly Robomongo)

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -790,6 +790,18 @@
       "category" : "database"
     },
     {
+      "repo_url" : "https://github.com/Studio3T/robomongo",
+      "title" : "Robo 3T",
+      "screenshots" : [
+        "https://robomongo.org/static/screens-transparent-6e2a44fd.png"
+      ],
+      "short_description" : "Robo 3T (formerly Robomongo) is the free lightweight GUI for MongoDB enthusiasts. ",
+      "languages" : [
+        "c++"
+      ],
+      "category" : "database"
+    },
+    {
       "repo_url" : "https://github.com/simplerocket-llc/OpenCashew",
       "title" : "Cashew",
       "screenshots" : [

--- a/applications.json
+++ b/applications.json
@@ -797,7 +797,7 @@
       ],
       "short_description" : "Robo 3T (formerly Robomongo) is the free lightweight GUI for MongoDB enthusiasts. ",
       "languages" : [
-        "c++"
+        "cpp"
       ],
       "category" : "database"
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/Studio3T/robomongo

## Category
database

## Description
Robo 3T (formerly Robomongo) is the free lightweight GUI for MongoDB enthusiasts.
 

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
