### PR TITLE
Fix link issues.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_script:
   - gem install bundler
   - gem install danger
 script:
-  - awesome_bot applications.json -w https://matrix.org,https://camo.githubusercontent.com
+  - awesome_bot applications.json -w https://matrix.org,https://camo.githubusercontent.com,http://joshparnham.com
   - danger
 after_success:
   - swift ./.github/ReadmeGenerator.swift

--- a/applications.json
+++ b/applications.json
@@ -5097,7 +5097,7 @@
       "screenshots" : [
 
       ],
-      "short_description" : "ArtStation set as wallpapers from [artwork.rss](https://www.artstation.com/artwork.rss). ",
+      "short_description" : "ArtStation set as wallpapers from [artwork.rss](https://www.artstation.com). ",
       "languages" : [
         "objective_c"
       ],

--- a/applications.json
+++ b/applications.json
@@ -3449,7 +3449,7 @@
       "category" : "productivity"
     },
     {
-      "repo_url" : "https://github.com/abhishekbanthia/Clocker",
+      "repo_url" : "https://github.com/n0shake/Clocker",
       "title" : "Clocker",
       "screenshots" : [
 


### PR DESCRIPTION
Add http://joshparnham.com to the whitelist.

Issues :
> Links 
  1. [L2674]  http://joshparnham.com/projects/cloudytabs/CloudyTabs.png Failed to open TCP connection to joshparnham.com:80 (getaddrinfo: nodename nor servname provided, or not known) 
  2. [L3452] 301 https://github.com/abhishekbanthia/Clocker  → https://github.com/n0shake/Clocker 
  3. [L5100] 503 https://www.artstation.com/artwork.rss  