### PR TITLE
Add Iconology

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -2403,6 +2403,18 @@
       "category" : "images"
     },
     {
+      "repo_url" : "https://github.com/liamrosenfeld/Iconology",
+      "title" : "Iconology",
+      "screenshots" : [
+
+      ],
+      "short_description" : "Edit Icons and then Export to Xcode, Icns, Ico, Favicon, Mac Iconset, or a Custom List of Sizes.",
+      "languages" : [
+        "swift"
+      ],
+      "category" : "images"
+    },
+    {
       "repo_url" : "https://github.com/kornelski/ImageAlpha",
       "title" : "ImageAlpha",
       "screenshots" : [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/liamrosenfeld/Iconology

## Category
images

## Description
Added the icon generator app 'Iconology' to the image section.
 
## Why It Should Be Included
It gives developers a method to quickly create icons from glyphs without the need to pay for any pro tools. It also integrates with Xcode (by automatically generating the import JSON) and can export additional filetypes (icns and ico) that many pro tools, such as Photoshop and illustrator, do not support without additional scripts.

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English