### PR TITLE
Add HoRNDIS

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -4134,6 +4134,18 @@
       "category" : "system"
     },
     {
+      "repo_url" : "https://github.com/jwise/HoRNDIS",
+      "title" : "HoRNDIS",
+      "screenshots" : [
+
+      ],
+      "short_description" : "Android USB tethering driver for macOS. ",
+      "languages" : [
+        "cpp"
+      ],
+      "category" : "system"
+    },
+    {
       "repo_url" : "https://github.com/brianmichel/Juice",
       "title" : "Juice",
       "screenshots" : [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/jwise/HoRNDIS

## Category
system

## Description
Android USB tethering driver for macOS
 
## Why it should be included
It gives you the opportunity to use your Android phone's native USB tethering mode to get Internet access.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
