### PR TITLE
Add Conferences.digital

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -5381,6 +5381,18 @@
         "objective_c"
       ],
       "category" : "text"
+    },
+    {
+      "repo_url" : "https://github.com/zagahr/Conferences.digital",
+      "title" : "Conferences.digital",
+      "screenshots" : [
+        "https://raw.githubusercontent.com/zagahr/Conferences.digital/master/.github/screenshot.png"
+      ],
+      "short_description" : "Best way to watch the latest and greatest videos from your favourite developer conferences for free on your Mac.",
+      "languages" : [
+        "swift"
+      ],
+      "category" : "video"
     }
   ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/zagahr/Conferences.digital

## Category
Video

## Description
Conferences.digital is the best way to watch the latest and greatest videos from your favourite developer conferences for free on your Mac. Either search specifically for conferences, talks, speakers or topics or simply browse through the catalog - you can add talks to your watchlist to save for later, favourite or continue watching where you left off.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English