### PR TITLE
add ElectronMail

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -5405,6 +5405,19 @@
         "swift"
       ],
       "category" : "video"
+    },
+    {
+      "repo_url" : "https://github.com/vladimiry/ElectronMail",
+      "title" : "ElectronMail",
+      "screenshots" : [
+        "https://raw.githubusercontent.com/vladimiry/ElectronMail/master/images/search.gif",
+        "https://raw.githubusercontent.com/vladimiry/ElectronMail/master/images/export.gif"
+      ],
+      "short_description" : "Unofficial desktop app for ProtonMail and Tutanota end-to-end encrypted email providers.",
+      "languages" : [
+        "typescript"
+      ],
+      "category" : "mail"
     }
   ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Adding ElectronMail.

## Project URL
https://github.com/vladimiry/ElectronMail

## Category
<!--- Category in Awesome macOS open source applications where the project will be added -->
Email

## Description
<!--- Describe your changes in detail -->
Unofficial desktop app for ProtonMail and Tutanota end-to-end encrypted email providers 

## Why it should be included to `Awesome macOS open source applications ` (optional)
The app provides unique features that are not supported by the official in-browser web clients. Such as for example offline access to the email messages, full-text search (fully functional in offline), multiple accounts support, automatic login, and many more (see [readme](https://github.com/vladimiry/ElectronMail/blob/master/README.md) file for details).

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
