### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ You can see in which language an app is written. Currently there are following l
 
 ### Mail
 - [Correo](https://github.com/amitmerchant1990/correo) - Menubar/taskbar Gmail App for Windows and macOS.  ![javascript_icon] 
-- [ElectronMail](https://github.com/vladimiry/ElectronMail) - Unofficial desktop app for ProtonMail and Tutanota end-to-end encrypted email providers. ![typescript_icon] 
+- [ElectronMail](https://github.com/vladimiry/ElectronMail) - Unofficial desktop app for ProtonMail and Tutanota end-to-end encrypted email providers. ![type_script_icon]
 - [Inboxer](https://github.com/denysdovhan/inboxer) - Unofficial Google Inbox Desktop App. ![javascript_icon] ![css_icon] 
 - [Nylas Mail](https://github.com/nylas/nylas-mail) - Extensible mail client.  ![javascript_icon] 
 - [Rambox](https://github.com/ramboxapp/community-edition) - Cross Platform messaging and emailing app that combines common web applications into one. ![javascript_icon] ![css_icon] 

--- a/applications.json
+++ b/applications.json
@@ -5415,7 +5415,7 @@
       ],
       "short_description" : "Unofficial desktop app for ProtonMail and Tutanota end-to-end encrypted email providers.",
       "languages" : [
-        "typescript"
+        "type_script"
       ],
       "category" : "mail"
     },


### PR DESCRIPTION
Signed-off-by: Seonggwon Yoon <keyakoto@gmail.com>

#375 
I fixed only the README icon badge, which was wrong, and I fixed the typo in applications.json because I knew to build a README at build time.

Thank you.