### PR TITLE
Add OpenInTerminal

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -2664,7 +2664,8 @@
     {
       "short_description" : "macOS app and Finder Sync Extension to open Terminal, iTerm, Hyper from Finder. ",
       "categories" : [
-        "finder"
+        "finder",
+        "terminal"
       ],
       "repo_url" : "https://github.com/onmyway133/FinderGo",
       "title" : "Finder Go",
@@ -7166,6 +7167,25 @@
       "screenshots" : [
         "https://raw.githubusercontent.com/lm-a/touch-emoji/master/touch-emoji-icon-screenshot.png",
         "https://raw.githubusercontent.com/lm-a/touch-emoji/master/touch-emoji-recent-screenshot.png"
+      ],
+      "official_site" : "",
+      "languages" : [
+        "swift"
+      ]
+    },
+    {
+      "short_description" : "✨ Finder Toolbar app for macOS to open the current directory in Terminal, iTerm or Hyper.",
+      "categories" : [
+        "finder",
+        "terminal"
+      ],
+      "repo_url" : "https://github.com/Ji4n1ng/OpenInTerminal",
+      "title" : "OpenInTerminal",
+      "icon_url" : "",
+      "screenshots" : [
+        "https://github.com/Ji4n1ng/OpenInTerminal/blob/master/screenshots/run.gif",
+        "https://github.com/Ji4n1ng/OpenInTerminal/blob/master/screenshots/run2.gif",
+        "https://github.com/Ji4n1ng/OpenInTerminal/blob/master/screenshots/selector.png"
       ],
       "official_site" : "",
       "languages" : [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/Ji4n1ng/OpenInTerminal

## Category
Finder, Terminal

## Description
✨ Finder Toolbar app for macOS to open the current directory in Terminal, iTerm or Hyper.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English