### PR TITLE
Add Touch Bar category to Contents section at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ You can see in which language an app is written. Currently there are following l
 - [Streaming](#streaming)
 - [System](#system)
 - [Terminal](#terminal)
+- [Touch Bar](#touch-bar)
 - [Utilities](#utilities)
 - [VPN & Proxy](#vpn--proxy)
 - [Video](#video)


### PR DESCRIPTION
Touch Bar category is in Applications section, but it is not in Contents section at readme. PR fix it.
