### PR TITLE
Add Motrix

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -7195,7 +7195,7 @@
     {
       "short_description" : "Display macOS Dock in Touch Bar.",
       "categories" : [
-        "touch-bar",
+        "touch-bar"
       ],
       "repo_url" : "https://github.com/pigigaldi/Pock",
       "title" : "Pock",

--- a/applications.json
+++ b/applications.json
@@ -2330,6 +2330,25 @@
       ]
     },
     {
+      "short_description" : "A full-featured download manager. ",
+      "categories" : [
+        "downloader"
+      ],
+      "repo_url" : "https://github.com/agalwood/Motrix",
+      "title" : "Motrix",
+      "icon_url" : "https://github.com/agalwood/Motrix/blob/master/build/256x256.png",
+      "screenshots" : [
+        "https://raw.githubusercontent.com/agalwood/Motrix/master/screenshots/motrix-task-list-empty-light%402x.png",
+        "https://raw.githubusercontent.com/agalwood/Motrix/master/screenshots/motrix-task-list-downloading-light%402x.png",
+        "https://raw.githubusercontent.com/agalwood/Motrix/master/screenshots/motrix-task-list-empty-dark%402x.png",
+        "https://raw.githubusercontent.com/agalwood/Motrix/master/screenshots/motrix-task-list-downloading-dark%402x.png"
+      ],
+      "official_site" : "https://motrix.app/",
+      "languages" : [
+        "javascript"
+      ]
+    },
+    {
       "short_description" : "macOS Video Downloader written in Swift and Objective-C.",
       "categories" : [
         "downloader"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/agalwood/Motrix

## Category
Downloader

## Description
Motrix is a full-featured download manager that supports downloading HTTP, FTP, BitTorrent, Magnet, Baidu Net Disk, etc.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
