### PR TITLE
Add Notarize

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -7229,7 +7229,7 @@
       "repo_url" : "https://github.com/macmade/Notarize",
       "title" : "Notarize",
       "screenshots" : [
-        "https://github.com/macmade/Notarize/raw/master/Assets/MainWindow.png"
+        "https://raw.githubusercontent.com/macmade/Notarize/master/Assets/MainWindow.png"
       ],
       "short_description" : "Notarization status monitoring tool for macOS, supporting multiple developer accounts",
       "languages" : [

--- a/applications.json
+++ b/applications.json
@@ -7224,6 +7224,18 @@
       "languages" : [
         "swift"
       ]
+    },
+    {
+      "repo_url" : "https://github.com/macmade/Notarize",
+      "title" : "Notarize",
+      "screenshots" : [
+        "https://github.com/macmade/Notarize/raw/master/Assets/MainWindow.png"
+      ],
+      "short_description" : "Notarization status monitoring tool for macOS, supporting multiple developer accounts",
+      "languages" : [
+        "swift"
+      ],
+      "category" : "Development"
     }
   ]
 }


### PR DESCRIPTION
## Project URL
https://github.com/macmade/Notarize

## Category
Development

## Description
Add Notarize a Notarization status monitoring tool for macOS, supporting multiple developer accounts. 
 
## Why it should be included to `Awesome macOS open source applications ` (optional)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English