### PR TITLE
Add KubeSwitch

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -2128,6 +2128,22 @@
       ]
     },
     {
+      "short_description" : "KubeSwitch lists the available kubernetes cluster contexts on the mac, in Mac's Menu bar. ",
+      "categories" : [
+        "web-development"
+      ],
+      "repo_url" : "http://github.com/nsriram/KubeSwitch",
+      "title" : "KubeSwitch",
+      "icon_url" : "",
+      "screenshots" : [
+        "https://raw.githubusercontent.com/nsriram/KubeSwitch/master/screenshot.png"
+      ],
+      "official_site" : "",
+      "languages" : [
+        "swift"
+      ]
+    },
+    {
       "short_description" : "Dedicated Mac app for website auditing and crawling. ",
       "categories" : [
         "web-development"

--- a/applications.json
+++ b/applications.json
@@ -2132,7 +2132,7 @@
       "categories" : [
         "web-development"
       ],
-      "repo_url" : "http://github.com/nsriram/KubeSwitch",
+      "repo_url" : "https://github.com/nsriram/KubeSwitch",
       "title" : "KubeSwitch",
       "icon_url" : "",
       "screenshots" : [

--- a/applications.json
+++ b/applications.json
@@ -2128,7 +2128,7 @@
       ]
     },
     {
-      "short_description" : "KubeSwitch lists the available kubernetes cluster contexts on the mac, in Mac's Menu bar. ",
+      "short_description" : "KubeSwitch lists the available kubernetes cluster contexts on the mac, in Mac's Menu bar.",
       "categories" : [
         "web-development"
       ],


### PR DESCRIPTION
## Project URL
https://github.com/nsriram/KubeSwitch

## Category
Web development

## Description
KubeSwitch lists the available kubernetes cluster contexts on the mac, in Mac's Menu bar. Using KubeSwitch users can

* View available kubernetes cluster contexts on their Mac
* View the current selected kubernetes cluster context
* Change the current selection for kubernetes cluster context
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
Its an effective utility for Kuberenetes Users to switch between contexts

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
