### PR TITLE
Add KubeContext

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -3661,7 +3661,8 @@
       "title" : "KubeContext",
       "icon_url" : "",
       "screenshots" : [
-
+        "https://raw.githubusercontent.com/turkenh/KubeContext/master/Image/SS3.png",
+        "https://raw.githubusercontent.com/turkenh/KubeContext/master/Image/SS4.png"
       ],
       "official_site" : "",
       "languages" : [

--- a/applications.json
+++ b/applications.json
@@ -3653,6 +3653,22 @@
       ]
     },
     {
+      "short_description" : "import, manage and switch between your Kubernetes contexts on Mac. ",
+      "categories" : [
+        "menubar"
+      ],
+      "repo_url" : "https://github.com/turkenh/KubeContext",
+      "title" : "KubeContext",
+      "icon_url" : "",
+      "screenshots" : [
+
+      ],
+      "official_site" : "",
+      "languages" : [
+        "swift"
+      ]
+    },
+    {
       "short_description" : "macOS app to change the screen brightness on the menubar. ",
       "categories" : [
         "menubar"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/turkenh/KubeContext

## Category
Menubar

## Description
Adding KubeContext

A small menu bar app for managing Kubernetes contexts.

Easily switch between contexts
Import/export contexts from/to kubeconfig files
Context name in menu bar
Assign colors to your contexts
Easy context management UI for renaming context, setting namespace and more.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
