### PR TITLE
Add wechsel

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -3,7 +3,7 @@
     {
       "short_description" : "manage bluetooth connections with your keyboard.",
       "categories" : [
-        "Utilities"
+        "utilities"
       ],
       "repo_url" : "https://github.com/friedrichweise/wechsel",
       "title" : "wechsel",
@@ -19,7 +19,7 @@
     {
       "short_description" : "cross platform e-book manager.",
       "categories" : [
-        "Utilities"
+        "utilities"
       ],
       "repo_url" : "https://github.com/kovidgoyal/calibre",
       "title" : "calibre",

--- a/applications.json
+++ b/applications.json
@@ -1,6 +1,22 @@
 {
   "applications" : [
     {
+      "short_description" : "manage bluetooth connections with your keyboard.",
+      "categories" : [
+        "Utilities"
+      ],
+      "repo_url" : "https://github.com/friedrichweise/wechsel",
+      "title" : "wechsel",
+      "icon_url" : "https://github.com/friedrichweise/wechsel/blob/master/wechsel/Assets.xcassets/AppIcon.appiconset/Artboard-2.png ",
+      "screenshots" : [
+        "https://github.com/friedrichweise/wechsel/blob/master/screenshot.png"
+      ],
+      "official_site" : "https://wechsel.weise.io",
+      "languages" : [
+        "swift"
+      ]
+    },
+    {
       "short_description" : "cross platform e-book manager.",
       "categories" : [
         "Utilities"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
[https://github.com/friedrichweise/wechsel](https://github.com/friedrichweise/wechsel/)

## Category
Utilities

## Description
Adding wechsel

wechsel (/ˈvɛksəl/) claims to simplify the interaction with bluetooth connections on macOS. Instead of using the builtin Bluetooth menu bar, you can seamlessly switch between bluetooth audio devices using your keyboard. The tool offers a global hotkey to display a Spotlight-like window.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
