### PR TITLE
Add Doughnut

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -4567,6 +4567,22 @@
       ]
     },
     {
+      "repo_url" : "https://github.com/CD1212/Doughnut",
+      "title" : "Doughnut",
+      "screenshots" : [
+        "https://raw.githubusercontent.com/CD1212/Doughnut/master/screenshot.png"
+      ],
+      "short_description" : "Podcast player and library for mac",
+      "languages" : [
+        "swift"
+      ],
+      "categories" : [
+          "podcast"
+      ],
+      "icon_url" : "",
+      "official_site" : ""
+    },
+    {
       "short_description" : "Elegant Microsoft To-Do desktop app.",
       "categories" : [
         "productivity"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/CD1212/Doughnut

## Category
Podcast

## Description
Added the Doughnut podcast app. The design and user experience are inspired by Instacast for Mac which was discontinued in 2015.
 
## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
