### PR TITLE
Add Quick Caption to applications.json.

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -7337,6 +7337,21 @@
       "categories" : [
         "screensaver"
       ]
+    },
+    {
+      "repo_url" : "https://github.com/LumingYin/Caption",
+      "official_site" : "https://itunes.apple.com/app/quick-caption/id1363610340",
+      "title" : "Quick Caption",
+      "screenshots" : [
+        "https://raw.githubusercontent.com/LumingYin/Caption/master/screenshot.jpg"
+      ],
+      "short_description" : "Transcribe and generate caption files (SRT, ASS and FCPXML) without manually entering time codes.",
+      "languages" : [
+        "swift"
+      ],
+      "categories" : [
+        "video"
+      ]
     }
   ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/LumingYin/Caption

## Category
Video

## Description
Transcribe and generate caption files (SRT, ASS and FCPXML) without manually entering time codes.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
Quick Caption empowers content creators to make their videos more accessible.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English