### PR TITLE
Added macOS sound re-enabler

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -5802,6 +5802,22 @@
             ]
         },
         {
+            "short_description": "Mac Sound Re-Enabler. ",
+            "categories": [
+                "utilities"
+            ],
+            "repo_url": "https://github.com/dragstor/mac-sound-fix",
+            "title": "mac-sound-fix",
+            "icon_url": "",
+            "screenshots": [
+                "https://camo.githubusercontent.com/2ec00a08b476bb6b62b64b1813e0b608dd819d6d/68747470733a2f2f692e696d6775722e636f6d2f483338735073662e706e67"
+            ],
+            "official_site": "https://stojkovic.dev/",
+            "languages": [
+                "swift"
+            ]
+        },
+        {
             "short_description": "macOS native app/widget for aria2 download tool. ",
             "categories": [
                 "utilities"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/dragstor/mac-sound-fix

## Category
Utilities

## Description
Simple app made to fix the sound issues (it going mute and not responsive to controls) that can happen while using an external HDMI monitor on macOS or while attaching/detaching headphones.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
Because it's open sourced and it's useful 😄 

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
