### PR TITLE
Added Shairport Sync Airplay audio receiver to applications.json

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -415,6 +415,21 @@
             ]
         },
         {
+            "short_description": "macOS/Linux/FreeBSD/OpenBSD Airplay audio receiver.",
+            "categories": [
+                "audio"
+            ],
+            "repo_url": "https://github.com/mikebrady/shairport-sync",
+            "title": "shairport-sync",
+            "icon_url": "",
+            "screenshots": [],
+            "official_site": "",
+            "languages": [
+                "c",
+                "cpp"
+            ]
+        },
+        {
             "short_description": "Keep your application settings in sync (macOS/Linux). ",
             "categories": [
                 "backup"


### PR DESCRIPTION
Signed-off-by: Clovis Durand <cd.clovel19@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Project URL
<!--- The project URL -->
https://github.com/mikebrady/shairport-sync

## Category
<!--- Category in Awesome macOS open source applications where the project will be added -->
Audio

## Description
<!--- Describe your changes in detail -->
Added Shairport Sync Airplay audio receiver project to the application list
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
This software is a great one to have an airplay audio receiver. 

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [ ] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English