### PR TITLE
Add Clementine Media Player

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -48,6 +48,25 @@
                 "swift"
             ]
         },
+         {
+            "short_description": "Clementine is a modern music player and library organizer for Windows, Linux and macOS. ",
+            "categories": [
+                "audio"
+            ],
+            "repo_url": "https://github.com/clementine-player/Clementine",
+            "title": "Clementine",
+            "icon_url": "https://raw.githubusercontent.com/clementine-player/Clementine/master/dist/clementine_128.png",
+            "screenshots": [
+                "https://clementine-player.github.io/pages/images/screenshots/clementine-1.2-1.png",
+                "https://clementine-player.github.io/pages/images/screenshots/clementine-1.2-2.png",
+                "https://clementine-player.github.io/pages/images/screenshots/clementine-1.2-3.png",
+                "https://clementine-player.github.io/pages/images/screenshots/clementine-1.2-4.png"
+            ],
+            "official_site": "http://www.clementine-player.org/",
+            "languages": [
+                "C++"
+            ]
+        },
         {
             "short_description": "Aural Player is a audio player application for the macOS platform. Inspired by the classic Winamp player for Windows, it is designed to be to-the-point and easy to use. ",
             "categories": [


### PR DESCRIPTION
Add Clementine is a modern music player and library organizer for macOS and other platforms


## Project URL
https://github.com/clementine-player/Clementine
## Category
Audio

## Description
Added  Clementine audio player
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
It has an intuitive user interface and its one stop place for music and online radio using services like icecast.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [ x] Only one project/change is in this pull request
- [ x] Screenshots(s) added if any
- [x ] Has a commit from less than 2 years ago
- [x ] Has a **clear** README in English
