### PR TITLE
Add HTTP Toolkit to applications

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -2045,6 +2045,24 @@
             ]
         },
         {
+            "short_description": "HTTP Toolkit is a cross-platform tool to intercept, debug & mock HTTP. ",
+            "categories": [
+                "web-development"
+            ],
+            "repo_url": "https://github.com/httptoolkit/httptoolkit-desktop",
+            "title": "HTTP Toolkit",
+            "icon_url": "https://httptoolkit.tech/icon-600.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/httptoolkit/httptoolkit.tech/master/src/images/inspect-screenshot.png",
+                "https://raw.githubusercontent.com/httptoolkit/httptoolkit.tech/master/src/images/intercept-screenshot.png",
+                "https://raw.githubusercontent.com/httptoolkit/httptoolkit.tech/master/src/images/edit-screenshot.png"                
+            ],
+            "official_site": "https://httptoolkit.tech",
+            "languages": [
+                "typescript"
+            ]
+        },        
+        {
             "short_description": "Insomnia is a cross-platform REST client, built on top of Electron. ",
             "categories": [
                 "web-development"


### PR DESCRIPTION
## Project URL

Main site: https://httptoolkit.tech/
Github org: https://github.com/httptoolkit/

## Category

Web Development

## Description

HTTP Toolkit is a 100% open-source app, built with TypeScript & Electron, that works beautifully on MacOS (in addition to other platforms). It's a broad spectrum suite of HTTP tools, to intercept, debug & mock any HTTP and HTTPS traffic.
 
## Why it should be included to `Awesome macOS open source applications

It's a popular, open-source & awesome tool.

## Checklist

- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
  Yes, although there are a few parts. There's the [desktop app](https://github.com/httptoolkit/httptoolkit-desktop) (which I've used as the main repo here), [the server](https://github.com/httptoolkit/httptoolkit-server) & [the UI](https://github.com/httptoolkit/httptoolkit-ui). Each has a readme on the technical details of the component and how they relate, and each links to https://httptoolkit.tech/ which explains the project overall from an end-user POV.
