### PR TITLE
Move MessagesHistoryBrowser to chat category

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1236,7 +1236,7 @@
         {
             "short_description": "macOS application to comfortably browse and search through your Messages.app history. ",
             "categories": [
-                "git"
+                "chat"
             ],
             "repo_url": "https://github.com/glaurent/MessagesHistoryBrowser",
             "title": "MessagesHistoryBrowser",


### PR DESCRIPTION
Seems to have been erroneously placed in the git category.

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [ ] Screenshots(s) added if any
- [ ] Has a commit from less than 2 years ago
- [ ] Has a **clear** README in English
