### PR TITLE
Add BlackHole for modern audio routing

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -7026,6 +7026,20 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "short_description": "BlackHole is a modern macOS virtual audio driver that allows applications to pass audio to other applications with zero additional latency.",
+            "categories": [
+                "audio"
+            ],
+            "repo_url": "https://github.com/ExistentialAudio/BlackHole",
+            "title": "BlackHole",
+            "icon_url": "",
+            "screenshots": [],
+            "official_site": "",
+            "languages": [
+                "c"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Project URLs

* https://github.com/ExistentialAudio/BlackHole

## Category

* Audio

## Description

Add BlackHole to `applications.json`, a modern MacOS virtual audio driver.

## Why it should be included to `Awesome macOS open source applications ` (optional)

Anyone recording podcasts or screencasts on MacOS will at some point want to capture audio from another app, or setup background music of some sort. This works on the latests version of MacOS and is simple to use and install.

## Checklist

 * [x]  Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
 * [x]  Only one project/change is in this pull request
 * [x]  Screenshots(s) added if any
 * [x]  Has a commit from less than 2 years ago
 * [x]  Has a **clear** README in English