### PR TITLE
Add espanso

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -4449,6 +4449,21 @@
             ]
         },
         {
+            "short_description": "Cross-platform Text Expander, a powerful replacement for Alfred Snippets",
+            "categories": [
+                "productivity"
+            ],
+            "repo_url": "https://github.com/federico-terzi/espanso",
+            "title": "espanso",
+            "screenshots": [
+                "https://raw.githubusercontent.com/federico-terzi/espanso/master/images/example.gif"
+            ],
+            "official_site": "https://espanso.org",
+            "languages": [
+                "rust"
+            ]
+        },
+        {
             "short_description": "Record shortcuts in macOS, like Alfred.app. ",
             "categories": [
                 "productivity"

--- a/applications.json
+++ b/applications.json
@@ -4458,6 +4458,7 @@
             "screenshots": [
                 "https://raw.githubusercontent.com/federico-terzi/espanso/master/images/example.gif"
             ],
+            "icon_url": "",
             "official_site": "https://espanso.org",
             "languages": [
                 "rust"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/federico-terzi/espanso

## Category
Productivity

## Description
A Cross-platform, System-Wide Text Expander written in Rust. Replaces text with something else while typing, boosting productivity.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)

This represents a valid and open-source alternative to the very popular Alfred's Snippets feature.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English
