### PR TITLE
Add Lilypond UI, an IDE for typesetting musical scores.

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -7026,6 +7026,22 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "short_description": "Create beautiful musical scores with LilyPond",
+            "categories": [
+                "music"
+            ],
+            "repo_url": "https://github.com/doches/lilypond-ui",
+            "title": "Lilypond UI",
+            "icon_url": "https://raw.githubusercontent.com/doches/lilypond-ui/develop/artwork/icons.iconset/icon_512x512.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/doches/lilypond-ui/develop/docs/lilypond-ide.png"
+            ],
+            "official_site": "https://github.com/doches/lilypond-ui",
+            "languages": [
+                "javascript"
+            ]
         }
     ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/doches/lilypond-ui

## Category
Either **Music** or **Editors**, as it's an editor for typesetting music.

## Description
Straightforward addition of a JSON block, in the specified format, that adds the app above.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
Because it's an easy-to-use app for working with a notoriously hard-to-use tool, and music typesetting is a niche that's currently unrepresented on this list.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
