### PR TITLE
Add Numi to list of applications

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -7253,6 +7253,20 @@
                 "Images",
                 "Video"
               ]
+        },
+        {
+            "short_description": "A handy calculator with natural language parsing",
+            "categories": [
+                "Utilities"
+            ],
+            "repo_url": "https://github.com/nikolaeu/Numi",
+            "title": "Numi",
+            "icon_url": "",
+            "screenshots": [],
+            "official_site": "https://numi.app",
+            "languages": [
+                "Javascript"
+            ]
         }
     ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/nikolaeu/Numi

## Category
Utilities

## Description
I added the Numi open source calculator app to the list of applications.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
