### PR TITLE
Update to include audio application cog

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -7187,13 +7187,13 @@
             "categories": [
                 "audio"
             ],
-            "repo_url": "https://kode54.net/cog/",
+            "repo_url": "https://bitbucket.org/losnoco/cog/src",
             "title": "Cog",
             "icon_url": "",
             "screenshots": [],
             "official_site": "http://cogx.org/",
             "languages": [
-                "Objective-C"
+                "objective_c"
             ]
         },
         {

--- a/applications.json
+++ b/applications.json
@@ -7182,6 +7182,20 @@
                 "c"
             ]
         },
+              {
+            "short_description": "Cog is an open source audio player for macOS. The basic layout is a single-paned playlist interface with two retractable drawers, one for navigating the user's music folders and another for viewing audio file properties, like bitrate",
+            "categories": [
+                "audio"
+            ],
+            "repo_url": "https://kode54.net/cog/",
+            "title": "Cog",
+            "icon_url": "",
+            "screenshots": [],
+            "official_site": "http://cogx.org/",
+            "languages": [
+                "Objective-C"
+            ]
+        },
         {
             "short_description" : "Command-line tool to search files with SQL syntax.",
             "categories" : [


### PR DESCRIPTION
Added the audio application with winamp like interface "cog"

<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://kode54.net/cog/

## Category
Audio

## Description
Added the audio application with winamp like interface "cog" to aplications.json
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
Great low memory application, esp if you want to manage your music in folders

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [ ] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English
