### PR TITLE
Adding Flying Carpet to utilities

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,6 +1,22 @@
 {
     "applications": [
         {
+            "short_description": "cross-platform file transfer over ad-hoc wifi, like AirDrop but for Mac/Windows/Linux.",
+            "categories": [
+                "utilities"
+            ],
+            "repo_url": "https://github.com/spieglt/flyingcarpet",
+            "title": "Flying Carpet",
+            "icon_url": "https://raw.githubusercontent.com/spieglt/FlyingCarpet/master/icons/Windows/fc.ico",
+            "screenshots": [
+                "https://github.com/spieglt/FlyingCarpet/blob/master/pictures/macDemo.png"
+            ],
+            "official_site": "https://adequate.systems/",
+            "languages": [
+                "go"
+            ]
+        },
+        {
             "short_description": "manage bluetooth connections with your keyboard.",
             "categories": [
                 "utilities"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/spieglt/flyingcarpet

## Category
Utilities

## Description
Adding one project
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
People would sometimes like to exchange files with other laptops without needing WiFi or uploading files to the cloud unnecessarily.

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
