### PR TITLE
Adding Cloaker to security section

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,6 +1,22 @@
 {
     "applications": [
         {
+            "short_description": "simple drag-and-drop, password-based file encryption.",
+            "categories": [
+                "security"
+            ],
+            "repo_url": "https://github.com/spieglt/cloaker",
+            "title": "Cloaker",
+            "icon_url": "https://raw.githubusercontent.com/spieglt/Cloaker/master/gui/cloaker/cloaker.ico",
+            "screenshots": [
+                "https://github.com/spieglt/Cloaker/blob/master/demo.gif"
+            ],
+            "official_site": "https://adequate.systems/",
+            "languages": [
+                "rust"
+            ]
+        },
+        {
             "short_description": "manage bluetooth connections with your keyboard.",
             "categories": [
                 "utilities"


### PR DESCRIPTION
## Project URL
https://github.com/spieglt/cloaker

## Category
Security

## Description
Adding Cloaker to the security section
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
People need a very simple way to encrypt files with a password. Legacy zip encryption is insecure and PGP is notoriously difficult to use.

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
