### PR TITLE
Add Audacity

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -7149,6 +7149,22 @@
             ]
         },
         {
+            "short_description": "Free, open source, cross-platform audio software",
+            "categories": [
+                "music"
+            ],
+            "repo_url": "https://github.com/audacity/audacity",
+            "title": "Audacity",
+            "icon_url": "https://avatars3.githubusercontent.com/u/11648186?s=200&v=4",
+            "screenshots": [
+                "https://www.audacityteam.org/wp-content/uploads/2017/12/Audacity-220-Mac-normal.png"
+            ],
+            "official_site": "https://www.audacityteam.org/",
+            "languages": [
+                "c"
+            ]
+        },
+         {
             "short_description": "Create beautiful musical scores with LilyPond",
             "categories": [
                 "music"


### PR DESCRIPTION
Audacity is a free and open-source digital audio editor and recording application software, available for Windows, macOS/OS X and Unix-like operating systems

<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://www.audacityteam.org/

## Category
Music

## Description
Audacity is a free and open-source digital audio editor and recording application software, available for Windows, macOS/OS X and Unix-like operating systems
 
## Why it should be included to `Awesome macOS open source applications ` (optional)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English
