### PR TITLE
Add Mac Homebrew Cask to Utilities

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -31,6 +31,22 @@
             ]
         },
         {
+            "short_description": "A CLI workflow for the administration of macOS applications distributed as binaries",
+            "categories": [
+                "utilities"
+            ],
+            "repo_url": "https://github.com/Homebrew/homebrew-cask",
+            "title": "homebrew-cask",
+            "icon_url": "https://brew.sh/assets/img/homebrew-256x256.png",
+            "screenshots": [
+                "https://camo.githubusercontent.com/e0232f054269f4da8df572c3dea4f08def189df3/68747470733a2f2f692e696d6775722e636f6d2f626a723855785a2e676966"
+            ],
+            "official_site": "https://brew.sh/",
+            "languages": [
+                "ruby"
+            ]
+        },
+        {
             "short_description": "Application which hosts AudioUnits v3 using AVFoundation API. ",
             "categories": [
                 "audio"


### PR DESCRIPTION
Though really Homebrew and Homebrew Cask should be their own "type"

Closes #315

Add Mac Homebrew Cask to Utilities

## Project URL
https://brew.sh

## Category
Utilitiy

## Description
Add Mac Homebrew Cask to Utilities
 
## Why it should be included to `Awesome macOS open source applications ` (optional)

In my opinion, [Homebrew](https://github.com/Homebrew/homebrew-core) and [Homebrew Cask](https://github.com/Homebrew/homebrew-cask) should be their own category and I am happy to add another PR

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English
