### PR TITLE
Updated Brave Browser URL in applications.json

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -563,7 +563,7 @@
             "categories": [
                 "browser"
             ],
-            "repo_url": "https://github.com/brave/browser-laptop",
+            "repo_url": "https://github.com/brave/brave-browser",
             "title": "Brave Browser",
             "icon_url": "",
             "screenshots": [],


### PR DESCRIPTION
The repository found at https://github.com/brave/browser-laptop has been archived by the owner. It is now read-only. 

Its description reads:
> [DEPRECATED] Please see https://github.com/brave/brave-browser for the current version of Brave

This pull request features one commit that updates the Brave Browser URL in applications.json to point directly to the current Brave repository.