### PR TITLE
Remove duplicate description tag in Iina app

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -6479,13 +6479,12 @@
             ]
         },
         {
-            "short_description": "Modern video player for macOS. ",
+            "short_description" : "The modern video player for macOS. ",
             "categories": [
                 "player"
             ],
             "repo_url": "https://github.com/iina/iina",
             "title": "IINA",
-            "short_description" : "The modern video player for macOS.",
             "icon_url": "https://raw.githubusercontent.com/iina/iina/master/iina/Assets.xcassets/AppIcon.appiconset/256-1.png",
             "screenshots": [],
             "official_site": "https://iina.io",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Changes
- JSON maintenance: Project description contained a duplicate `short_description` line, so I took out the extra one.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
