### PR TITLE
Remove Android Messenger for Mac

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -666,22 +666,6 @@
             ]
         },
         {
-            "short_description": " Mac app wrapper around Google's stand-alone Android Messenger. ",
-            "categories": [
-                "chat"
-            ],
-            "repo_url": "https://github.com/larson-carter/android-messenger-mac",
-            "title": "Android Messenger Mac",
-            "icon_url": "",
-            "screenshots": [
-                "https://i.imgur.com/GQiLntX.jpg"
-            ],
-            "official_site": "",
-            "languages": [
-                "javascript"
-            ]
-        },
-        {
             "short_description": "Powerful XMPP client with support for file transfer, VoIP and end-to-end encryption.",
             "categories": [
                 "chat"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/larson-carter/android-messenger-mac/blob/master/README.md

## Category
Chat

 ## Why it should be ~included to~ removed from `Awesome macOS open source applications `

- Wrapper doesn't work anymore as stated by the original maintainer.


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
