### PR TITLE
Fix typescript icons for multiple apps

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -2174,7 +2174,7 @@
             ],
             "official_site": "https://httptoolkit.tech/mock/",
             "languages": [
-                "typescript"
+                "type_script"
             ]
         },
         {
@@ -7444,7 +7444,7 @@
             ],
             "official_site": "https://super-productivity.com",
             "languages": [
-                "typescript",
+                "type_script",
                 "javascript"
             ]
         },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Changes

- multiple apps were using `typescript` inside the `languages` field, which would not render correctly
- this changes all instances to `type_script`

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
