### PR TITLE
Add nef Xcode extension to list

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -2683,23 +2683,6 @@
             ]
         },
         {
-            "short_description": "This Xcode extension enables you to make a code selection and export it to a snippets. Available on Mac AppStore.",
-            "categories": [
-                "extensions"
-            ],
-            "repo_url": "https://github.com/bow-swift/nef-plugin",
-            "title": "nef",
-            "icon_url": "https://raw.githubusercontent.com/bow-swift/bow-art/master/assets/nef-brand-xcode-shadow.png",
-            "screenshots": [
-                "https://raw.githubusercontent.com/bow-swift/nef-plugin/master/assets/nef-plugin-action-export.png",
-                "https://raw.githubusercontent.com/bow-swift/nef-plugin/master/assets/nef-plugin-action-snippet.png"
-            ],
-            "official_site": "",
-            "languages": [
-                "swift"
-            ]
-        },
-        {
             "short_description": "PiPifier is a native macOS 10.12 Safari extension that lets you use every HTML5 video in Picture in Picture mode. ",
             "categories": [
                 "extensions"
@@ -2729,6 +2712,23 @@
             "official_site": "",
             "languages": [
                 "javascript"
+            ]
+        },
+        {
+            "short_description": "This Xcode extension enables you to make a code selection and export it to a snippets. Available on Mac AppStore.",
+            "categories": [
+                "extensions"
+            ],
+            "repo_url": "https://github.com/bow-swift/nef-plugin",
+            "title": "nef",
+            "icon_url": "https://raw.githubusercontent.com/bow-swift/bow-art/master/assets/nef-brand-xcode-shadow.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/bow-swift/nef-plugin/master/assets/nef-plugin-action-export.png",
+                "https://raw.githubusercontent.com/bow-swift/nef-plugin/master/assets/nef-plugin-action-snippet.png"
+            ],
+            "official_site": "https://nef.bow-swift.io/",
+            "languages": [
+                "swift"
             ]
         },
         {

--- a/applications.json
+++ b/applications.json
@@ -2683,6 +2683,23 @@
             ]
         },
         {
+            "short_description": "This Xcode extension enables you to make a code selection and export it to a snippets. Available on Mac AppStore.",
+            "categories": [
+                "extensions"
+            ],
+            "repo_url": "https://github.com/bow-swift/nef-plugin",
+            "title": "nef",
+            "icon_url": "https://raw.githubusercontent.com/bow-swift/bow-art/master/assets/nef-brand-xcode-shadow.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/bow-swift/nef-plugin/master/assets/nef-plugin-action-export.png",
+                "https://raw.githubusercontent.com/bow-swift/nef-plugin/master/assets/nef-plugin-action-snippet.png"
+            ],
+            "official_site": "",
+            "languages": [
+                "swift"
+            ]
+        },
+        {
             "short_description": "PiPifier is a native macOS 10.12 Safari extension that lets you use every HTML5 video in Picture in Picture mode. ",
             "categories": [
                 "extensions"


### PR DESCRIPTION
## Project URL
https://github.com/bow-swift/nef-plugin

## Category
Extensions

## Description
This project provides an extension for Xcode to integrate some nef features directly in the IDE. Using the core of nef, you can export snippets from your code selection directly in Xcode.
 
## Why it should be included in Awesome macOS open source applications 
You know all of those code screenshots you see on social networks, or at meetups and conferences? Do you want to share images of your code with your team? This Xcode extension makes it easy to create and share beautiful images of your source code.

## Screenshots
![nef-plugin-action-export](https://user-images.githubusercontent.com/25568562/67399407-7fded200-f5ac-11e9-9b2e-8adf5e585797.png)
![Screenshot 2019-10-23 at 15 52 00](https://user-images.githubusercontent.com/25568562/67399863-24611400-f5ad-11e9-9e49-7dcf7dceaf26.png)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
