### PR TITLE
Adding Air Pasteboard open source app

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -7497,6 +7497,25 @@
                 "cpp",
                 "objective_c"
             ]
+        },
+        {
+            "short_description": "Quickly share pasteboard to Gist, and files via iCloud or Dropbox",
+            "categories": [
+                "Productivity"
+            ],
+            "repo_url": "https://github.com/msztech/AirPasteboardOpen",
+            "title": "Air Pasteboard",
+            "icon_url": "https://github.com/msztech/AirPasteboardOpen/blob/master/AirPasteBoard/Assets.xcassets/StatusBarButtonImage.imageset/bar32w.png?raw=true",
+            "screenshots": [
+               "https://github.com/msztech/AirPasteboardOpen/raw/master/demo.gif",
+               "https://is2-ssl.mzstatic.com/image/thumb/Purple123/v4/89/e9/4d/89e94d16-b39f-e726-685b-4e45fb39d915/pr_source.png/626x0w.png",
+               "https://is1-ssl.mzstatic.com/image/thumb/Purple123/v4/82/61/24/82612431-1249-606d-6edb-2bc4981bf54d/pr_source.png/626x0w.png",
+               "https://is2-ssl.mzstatic.com/image/thumb/Purple113/v4/ec/9a/2f/ec9a2f94-85cb-96f3-0df8-738c901b98d3/pr_source.png/626x0w.png"
+            ],
+            "official_site": "https://apps.apple.com/us/app/air-pasteboard/id1327733671?mt=12",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }

--- a/applications.json
+++ b/applications.json
@@ -7501,13 +7501,13 @@
         {
             "short_description": "Quickly share pasteboard to Gist, and files via iCloud or Dropbox",
             "categories": [
-                "Productivity"
+                "productivity"
             ],
             "repo_url": "https://github.com/msztech/AirPasteboardOpen",
             "title": "Air Pasteboard",
-            "icon_url": "https://github.com/msztech/AirPasteboardOpen/blob/master/AirPasteBoard/Assets.xcassets/StatusBarButtonImage.imageset/bar32w.png?raw=true",
+            "icon_url": "https://raw.githubusercontent.com/mszopensource/AirPasteboardOpen/master/AirPasteBoard/Assets.xcassets/StatusBarButtonImage.imageset/bar32w.png",
             "screenshots": [
-               "https://github.com/msztech/AirPasteboardOpen/raw/master/demo.gif",
+               "https://raw.githubusercontent.com/mszopensource/AirPasteboardOpen/master/demo.gif",
                "https://is2-ssl.mzstatic.com/image/thumb/Purple123/v4/89/e9/4d/89e94d16-b39f-e726-685b-4e45fb39d915/pr_source.png/626x0w.png",
                "https://is1-ssl.mzstatic.com/image/thumb/Purple123/v4/82/61/24/82612431-1249-606d-6edb-2bc4981bf54d/pr_source.png/626x0w.png",
                "https://is2-ssl.mzstatic.com/image/thumb/Purple113/v4/ec/9a/2f/ec9a2f94-85cb-96f3-0df8-738c901b98d3/pr_source.png/626x0w.png"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/msztech/AirPasteboardOpen

## Category
Productivity

## Description
I added my open source project `Air Pasteboard` to this repository. It allows quick pasteboard sharing to Github Gist and file sharing through iCloud and Dropbox. Users can easily use the system bar icon to share the pasteboard, or drag and drop to share a file.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
- Sharing codes and files fast are crucial for developers and I think this app can help developers to do so quickly.
- Also this app will help developers to understand how to create a system bar Mac OS app, how to use the drag and drop feature on system bar apps, how to use Github api, and how to use the Dropbox Swift framework.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
