### PR TITLE
Replace Nylas to the newer version 

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ You can see in which language an app is written. Currently there are following l
 ### Mail
 - [Correo](https://github.com/amitmerchant1990/correo) - Menubar/taskbar Gmail App for Windows and macOS.  ![javascript_icon] 
 - [ElectronMail](https://github.com/vladimiry/ElectronMail) - Unofficial desktop app for ProtonMail and Tutanota end-to-end encrypted email providers. ![type_script_icon] 
-- [Nylas Mail](https://github.com/nylas/nylas-mail) - Extensible mail client.  ![javascript_icon] 
+- [Mailspring](https://github.com/Foundry376/Mailspring) - 💌 A beautiful, fast and maintained fork of @nylas Mail by one of the original authors ![javascript_icon] 
 - [Rambox](https://github.com/ramboxapp/community-edition) - Cross Platform messaging and emailing app that combines common web applications into one. ![javascript_icon] ![css_icon] 
 - [dejalu](https://github.com/dinhviethoa/dejalu) - Fast and Simple Email Client. ![cpp_icon] ![objective_c_icon] 
 

--- a/applications.json
+++ b/applications.json
@@ -3493,15 +3493,15 @@
             ]
         },
         {
-            "short_description": "Extensible mail client. ",
+            "short_description": "💌 A beautiful, fast and maintained fork of @nylas Mail by one of the original authors",
             "categories": [
                 "mail"
             ],
-            "repo_url": "https://github.com/nylas/nylas-mail",
-            "title": "Nylas Mail",
+            "repo_url": "https://github.com/Foundry376/Mailspring",
+            "title": "Mailspring",
             "icon_url": "",
             "screenshots": [],
-            "official_site": "",
+            "official_site": "https://getmailspring.com/",
             "languages": [
                 "javascript"
             ]


### PR DESCRIPTION
Here is quite from repo: 
> **⚠️ Nylas Mail was initially released and open-sourced in early 2015 and was maintained by Nylas until Spring 2017.** While Nylas no longer supports Nylas Mail, you can download the latest release or build it from source. There are also **[several forks](#forks)** that are being actively developed and maintained.