### PR TITLE
Add QOwnNotes

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -4156,6 +4156,24 @@
             ]
         },
         {
+            "short_description": "Plain-text file notepad and todo-list manager with markdown support and ownCloud / Nextcloud integration.",
+            "categories": [
+                "markdown",
+                "notes",
+                "productivity"
+            ],
+            "repo_url": "https://github.com/pbek/QOwnNotes",
+            "title": "QOwnNotes",
+            "icon_url": "https://raw.githubusercontent.com/pbek/QOwnNotes/develop/icons/icon.png",
+            "screenshots": [
+               "https://www.qownnotes.org/var/bekerle/storage/images/_aliases/frontpage_slider_full2/qownnotes/frontpage-slider/qownnotes-main-screen-minimal-linux/4706-1-eng-GB/QOwnNotes-Main-Screen-Minimal-Linux.png"
+            ],
+            "official_site": "https://www.qownnotes.org/",
+            "languages": [
+                "cpp"
+            ]
+        },
+        {
             "short_description": "Manage your Homebrew formulas with style using Cakebrew. ",
             "categories": [
                 "other"


### PR DESCRIPTION
## Project URL
https://www.qownnotes.org/

## Category
Markdown, Notes, Productivity

## Description
Plain-text file notepad and todo-list manager with markdown support and ownCloud / Nextcloud integration.

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago — "Latest commit 13 hours ago"
- [x] Has a **clear** README in English
