### PR TITLE
Remove Sketch Toolbox entry (deprecated)

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -3004,7 +3004,7 @@
             "icon_url": "",
             "screenshots": [
                 "https://raw.githubusercontent.com/sindresorhus/gifski-app/master/Stuff/screenshot2.jpg",
-                "https://raw.githubusercontent.com/sindresorhus/gifski-app/master/Stuff/screenshot.jpg",
+                "https://raw.githubusercontent.com/sindresorhus/gifski-app/master/Stuff/screenshot1.jpg",
                 "https://raw.githubusercontent.com/sindresorhus/gifski-app/master/Stuff/AppIcon-readme.png"
             ],
             "official_site": "",

--- a/applications.json
+++ b/applications.json
@@ -5602,7 +5602,7 @@
             "categories": [
                 "terminal"
             ],
-            "repo_url": "https://github.com/jwilm/alacritty",
+            "repo_url": "https://github.com/alacritty/alacritty",
             "title": "Alacritty",
             "icon_url": "",
             "screenshots": [

--- a/applications.json
+++ b/applications.json
@@ -3092,23 +3092,6 @@
             ]
         },
         {
-            "short_description": "Plugin manager for Sketch.app.",
-            "categories": [
-                "graphics"
-            ],
-            "repo_url": "https://github.com/buzzfeed/Sketch-Toolbox",
-            "title": "Sketch Toolbox",
-            "icon_url": "",
-            "screenshots": [
-                "https://i.cloudup.com/XTLlL1-Stt-3000x3000.png"
-            ],
-            "official_site": "",
-            "languages": [
-                "objective_c",
-                "c"
-            ]
-        },
-        {
             "short_description": "The hackable text editor. ",
             "categories": [
                 "ide"


### PR DESCRIPTION
## Project URL
https://github.com/buzzfeed/Sketch-Toolbox

## Category
Grpahics

## Description
Remove Sketch Toolbox because it has been deprecated.