### PR TITLE
Remove Telegram's deprecated entry

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -875,20 +875,6 @@
             ]
         },
         {
-            "short_description": "Source code of deprecated Telegram for macOS version. ",
-            "categories": [
-                "chat"
-            ],
-            "repo_url": "https://github.com/overtake/telegram",
-            "title": "Telegram [Deprecated]",
-            "icon_url": "",
-            "screenshots": [],
-            "official_site": "",
-            "languages": [
-                "objective_c"
-            ]
-        },
-        {
             "short_description": "Telegram Desktop messaging app. ",
             "categories": [
                 "chat"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
<!--- The project URL -->
https://github.com/overtake/telegram

## Category
<!--- Category in Awesome macOS open source applications where the project will be added -->
Chat

## Description
<!--- Describe your changes in detail -->
Removes Telegram's deprecated entry on `applications.json`