### PR TITLE
Add Middleclick

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,6 +627,7 @@ You can see in which language an app is written. Currently there are following l
 - [mac-sound-fix](https://github.com/dragstor/mac-sound-fix) - Mac Sound Re-Enabler.  ![swift_icon] 
 - [wechsel](https://github.com/friedrichweise/wechsel) - manage bluetooth connections with your keyboard. ![swift_icon] 
 - [Übersicht](https://github.com/felixhageloh/uebersicht) - Keep an eye on what's happening on your machine and in the world.  ![objective_c_icon] 
+- [Middleclick] (https://github.com/DaFuqtor/MiddleClick-Catalina) - Emulate a scroll wheel click with three finger Click or Tap on MacBook trackpad and Magic Mouse. ![c_icon]
 
 ### VPN & Proxy
 - [ShadowsocksX-NG](https://github.com/shadowsocks/ShadowsocksX-NG) - Next Generation of ShadowsocksX.  ![swift_icon] 

--- a/applications.json
+++ b/applications.json
@@ -7565,7 +7565,7 @@
             ],
             "repo_url": "https://github.com/DaFuqtor/MiddleClick-Catalina",
             "title": "Middleclick",
-            "icon_url": "https://github.com/DaFuqtor/MiddleClick-Catalina/raw/master/MiddleClick/Images.xcassets/AppIcon.appiconset/mouse128x128.png",
+            "icon_url": "https://raw.githubusercontent.com/DaFuqtor/MiddleClick-Catalina/master/MiddleClick/Images.xcassets/AppIcon.appiconset/mouse128x128.png",
             "screenshots": [
                "https://github.com/DaFuqtor/MiddleClick-Catalina/blob/master/demo.png"
             ],

--- a/applications.json
+++ b/applications.json
@@ -7601,7 +7601,7 @@
             "screenshots": [
                "https://github.com/DaFuqtor/MiddleClick-Catalina/blob/master/demo.png"
             ],
-            "official_site": "https://github.com/DaFuqtor/MiddleClick-Catalina",
+            "official_site": "",
             "languages": [
                 "c"
             ]

--- a/applications.json
+++ b/applications.json
@@ -7555,6 +7555,24 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "short_description": "Emulate a scroll wheel click with three finger Click or Tap on MacBook trackpad and Magic Mouse",
+            "categories": [
+                "productivity",
+                "extensions",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/DaFuqtor/MiddleClick-Catalina",
+            "title": "Middleclick",
+            "icon_url": "https://github.com/DaFuqtor/MiddleClick-Catalina/raw/master/MiddleClick/Images.xcassets/AppIcon.appiconset/mouse128x128.png",
+            "screenshots": [
+               "https://github.com/DaFuqtor/MiddleClick-Catalina/blob/master/demo.png"
+            ],
+            "official_site": "https://github.com/DaFuqtor/MiddleClick-Catalina",
+            "languages": [
+                "c"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Emulate a scroll wheel click with three finger Click or Tap on MacBook trackpad and Magic Mouse with macOS Catalina10.15 support!

## Project URL
https://github.com/DaFuqtor/MiddleClick-Catalina

## Category
productivity, utilities, extensions

## Description
<!--- Describe your changes in detail -->
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
This is what I was missing using (great btw) trachpad in mac

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
