### PR TITLE
Add Swifty password manager

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -4400,6 +4400,23 @@
             ]
         },
         {
+            "short_description": "Free and offline password manager. ",
+            "categories": [
+                "security"
+            ],
+            "repo_url": "https://github.com/swiftyapp/swifty",
+            "title": "Swifty",
+            "icon_url": "https://getswifty.pro/images/brand@2x.png",
+            "screenshots": [
+                "https://alchaplinsky.com/images/misc/swifty_screen_01.png",
+                "https://alchaplinsky.com/images/misc/swifty_screen_02.png"
+            ],
+            "official_site": "https://getswifty.pro",
+            "languages": [
+                "javascript"
+            ]
+        },
+        {
             "short_description": "Frugal nativemacOS macOS Syncthing application bundle. ",
             "categories": [
                 "other"


### PR DESCRIPTION
Add Swifty password manger

## Project URL
http://getswifty.pro

## Category
Security

## Description
Update `applications.json` to add Swifty password manager to the list of apps and security category

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
