### PR TITLE
Add Mac Screenshot Tracker

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -7706,6 +7706,23 @@
                 "javascript",
                 "type_script"
             ]
+        },
+        {
+            "short_description": "An open source, free and hackable screenshot tracker. Re-watch what you've been working on!",
+            "categories": [
+                "productivity"
+            ],
+            "repo_url": "https://github.com/instance01/mac-screenshot-tracker",
+            "title": "Mac Screenshot Tracker",
+            "icon_url": "",
+            "screenshots": [
+                "https://raw.githubusercontent.com/instance01/mac-screenshot-tracker/master/.github/screen1.png",
+                "https://raw.githubusercontent.com/instance01/mac-screenshot-tracker/master/.github/screen2.png"
+            ],
+            "official_site": "",
+            "languages": [
+                "python"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Project URL
https://github.com/instance01/mac-screenshot-tracker

## Category
Productivity

## Description
Become more productive by reviewing what you've been working on. This application runs in the background and creates low-resolution screenshots every 60 or so (can be changed) seconds. After a tough day full of work you can then watch what you've been doing. Maybe you find that you waste a surprisingly huge amount of time on random things.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
It's a completely free alternative to the many screenshot trackers out there. It is very simple and hackable. It gets the job done!

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any: See applications.json
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
