### PR TITLE
Add tuner app

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -7707,5 +7707,23 @@
                 "type_script"
             ]
         }
+        {
+            "short_description": "Musical Instrument Tuner",
+            "categories": [
+                "audio"
+            ],
+            "repo_url": "https://github.com/billthefarmer/ctuner",
+            "title": "Tuner",
+            "icon_url": "https://github.com/billthefarmer/ctuner/raw/master/swift/Tuner.png",
+            "screenshots": [
+                "https://github.com/billthefarmer/billthefarmer.github.io/raw/master/images/ctuner/Tuner-swift.png",
+                "https://github.com/billthefarmer/billthefarmer.github.io/raw/master/images/ctuner/Tuner-preferences.png",
+                "https://github.com/billthefarmer/billthefarmer.github.io/raw/master/images/ctuner/Note-filter.png"
+            ],
+            "official_site": "https://billthefarmer.github.io/ctuner",
+            "languages": [
+                "swift"
+            ]
+        }
     ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
<!--- The project URL -->
https://github.com/billthefarmer/ctuner
## Category
<!--- Category in Awesome macOS open source applications where the project will be added -->
Audio
## Description
<!--- Describe your changes in detail -->
 I have added an entry for my Tuner app. Note there are five versions of this app, four in this repository &ndash; windows, linux, old macOS using C, new macOS using Swift. The README for the Swift version is in https://github.com/billthefarmer/ctuner/tree/master/swift. And an android version https://github.com/billthefarmer/tuner.
## Why it should be included to `Awesome macOS open source applications ` (optional)
You don't appear to have a macOS tuner app. I also have macOS signal generator and oscilloscope apps which I will add.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [ x ] Only one project/change is in this pull request
- [ x ] Screenshots(s) added if any
- [ x ] Has a commit from less than 2 years ago
- [ x ] Has a **clear** README in English
