### PR TITLE
Remove ClashX

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -6264,20 +6264,6 @@
             ]
         },
         {
-            "short_description": "A rule based custom proxy with GUI for Mac base on clash. ",
-            "categories": [
-                "vpn--proxy"
-            ],
-            "repo_url": "https://github.com/yichengchen/clashX",
-            "title": "clashX",
-            "icon_url": "",
-            "screenshots": [],
-            "official_site": "",
-            "languages": [
-                "swift"
-            ]
-        },
-        {
             "short_description": "Ribose VPN Client macOS Menu App. ",
             "categories": [
                 "vpn--proxy"


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
ClashX repo - https://github.com/yichengchen/clashX has only one file.
It should not be included in this list


## Category
NA

## Description
NA
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
To help clean up invalid applications from this awesome list


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [ x] Only one project/change is in this pull request
- [ ] Screenshots(s) added if any
- [ ] Has a commit from less than 2 years ago
- [ ] Has a **clear** README in English
