### PR TITLE
Added new JSON to Model generator app

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,8 @@ You can see in which language an app is written. Currently there are following l
 #### JSON Parsing
 - [JSON Mapper](https://github.com/AppCraft-LLC/json-mapper) - Simple macOS app to generate Swift Object Mapper classes from JSON.  ![swift_icon] 
 - [JSONExport](https://github.com/Ahmed-Ali/JSONExport) - Desktop application for macOS which enables you to export JSON objects as model classes with their associated constructors, utility methods, setters and getters in your favorite language.  ![swift_icon] 
-- [j2s](https://github.com/zadr/j2s) - macOS app to convert JSON objects into Swift structs (currently targets Swift 4 and Codable).  ![swift_icon] 
+- [j2s](https://github.com/zadr/j2s) - macOS app to convert JSON objects into Swift structs (currently targets Swift 4 and Codable).  ![swift_icon]
+- [JSON to Model class](https://github.com/chanonly123/Json-Model-Generator) - Template based highly customizable macOS app to generate classes from JSON string, supports many languages.  ![swift_icon]
 
 #### Other Development
 - [ChefInspector](https://github.com/Yasumoto/ChefInspector) - Node and Attribute viewer for Chef  ![swift_icon] 


### PR DESCRIPTION
Added new JSON to Model class generator app in JSON Parsing section

## Project URL
https://github.com/chanonly123/Json-Model-Generator

## Category
JSON Parsing

## Description
Only one change in readme.md file, just added my new app "JSON to Model class generator"
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
This app uses template to generate model classes, so it is highly customisable and also supports templates created by user. Also supports many languages.


## Checklist
- [ ] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [ ] Screenshots(s) added if any
- [ ] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
