### PR TITLE
Added new mac app for JSON to model class generator

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -2106,6 +2106,22 @@
             ]
         },
         {
+          "short_description": "Template based highly customizable macOS app to generate classes from JSON string, supports many languages. ",
+          "categories": [
+            "json-parsing"
+          ],
+          "repo_url": "https://github.com/chanonly123/Json-Model-Generator",
+          "title": "JSON to Model class",
+          "icon_url": "",
+          "screenshots": [
+            "https://github.com/chanonly123/Json-Model-Generator/raw/master/demo1.png"
+          ],
+          "official_site": "",
+          "languages": [
+            "swift"
+          ]
+        },
+        {
             "short_description": "Simple macOS app for uploading files to Amazon Web Services. ",
             "categories": [
                 "web-development"


### PR DESCRIPTION
Added new JSON to Model class generator app in JSON Parsing section

## Project URL
https://github.com/chanonly123/Json-Model-Generator

## Category
json-Parsing

## Description
Only one change in readme.md file, just added my new app "JSON to Model class generator"
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
This app uses template to generate model classes, so it is highly customisable and also supports templates created by user. Also supports many languages.

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
