### PR TITLE
Add Grayscale Mode

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -7689,6 +7689,24 @@
             ]
         },
         {
+            "short_description": "Manage grayscale mode from menu bar.",
+            "categories": [
+                "utilities",
+                "menubar"
+            ],
+            "repo_url": "https://github.com/rkbhochalya/grayscale-mode",
+            "title": "Grayscale Mode",
+            "icon_url": "https://user-images.githubusercontent.com/12229032/78544116-48d94180-7817-11ea-9612-7a596f897e02.png",
+            "screenshots": [
+                "https://user-images.githubusercontent.com/12229032/78544215-6b6b5a80-7817-11ea-8b80-12bbbfc16053.jpg",
+                "https://user-images.githubusercontent.com/12229032/78544289-84740b80-7817-11ea-9092-e76fcb027702.jpg"
+            ],
+            "official_site": "https://grayscalemode.com",
+            "languages": [
+                "swift"
+            ]
+        },
+        {
             "short_description": "An elegant Cross-platform MQTT 5.0 desktop client.",
             "categories": [
                 "other-development",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/rkbhochalya/grayscale-mode

## Category
- `utilities`
- `menubar`

## Description
Grayscale Mode is a macOS app that lets you quickly toggle grayscale filter right from your menu bar or using a keyboard shortcut (⌥⌘G).
 
## Why it should be included to `Awesome macOS open source applications ` (optional)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
