### PR TITLE
Add Ultra TabSaver

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -20,6 +20,25 @@
             ]
         },
         {
+           "short_description": "Ultra TabSaver is an open-source Tab Manager for Safari",
+           "categories": [
+               "extensions",
+               "productivity",
+               "utilities"
+           ],
+           "repo_url": "https://github.com/morsamatias/UltraTabSaver",
+           "title": "Ultra TabSaver",
+           "icon_url": "https://raw.githubusercontent.com/morsamatias/UltraTabSaver/master/Ultra%20TabSaver/Assets.xcassets/AppIcon.appiconset/unnamed-1.png",
+           "screenshots": [
+              "https://raw.githubusercontent.com/morsamatias/UltraTabSaver/master/Screenshoot-1.png",
+              "https://raw.githubusercontent.com/morsamatias/UltraTabSaver/master/Screenshoot-2.png"
+           ],
+           "official_site": "",
+           "languages": [
+               "Swift"
+           ]
+       },
+        {
             "short_description": "Music Bar is macOS application that places music controls right in your menu bar.",
             "categories": [
                 "audio",

--- a/applications.json
+++ b/applications.json
@@ -35,7 +35,7 @@
            ],
            "official_site": "",
            "languages": [
-               "Swift"
+               "swift"
            ]
        },
         {


### PR DESCRIPTION
Add Ultra TabSaver to the list of apps.

## Project URL
https://github.com/morsamatias/UltraTabSaver

## Category
Extensions

## Description
open source Tabs Manager for Safari.
 
## Why it should be included to `Awesome macOS open source applications `
There isn't any other Tab Manager open source for safari.
## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
