### PR TITLE
Suggest Apache NetBeans as a candidate

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,22 +1,23 @@
+# Added Apache NetBeans as candidate
 <!--- Provide a general summary of your changes in the Title above -->
 
 ## Project URL
-<!--- The project URL -->
+http://netbeans.apache.org
 
 ## Category
-<!--- Category in Awesome macOS open source applications where the project will be added -->
+IDE, development
 
 ## Description
-<!--- Describe your changes in detail -->
- 
-## Why it should be included to `Awesome macOS open source applications ` (optional)
+NetBeans is both an IDE and a platform for development. NetBeans is an integrated development environment (IDE) for Java, PHP, C, C++, HTML5,[4] and JavaScript. The NetBeans Platform is a framework for simplifying the development of Swing desktop applications. The NetBeans IDE bundle for Java SE contains what is needed to start developing NetBeans plugins and NetBeans Platform based applications; no additional SDK is required.
 
+## Why it should be included to `Awesome macOS open source applications ` (optional)
+NetBeans has been accepted by Apache as a top-level project. It has a stable and engaged development community who have been driving development of the application for many years. There is a supportive community for new and experienced users. All Apache NetBeans source code is freely available to build yourself, or you can download (unsupported) daily development builds.
 
 ## Checklist
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-- [ ] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
-- [ ] Only one project/change is in this pull request
-- [ ] Screenshots(s) added if any
-- [ ] Has a commit from less than 2 years ago
+- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
+- [x] Only one project/change is in this pull request
+- [x] Screenshots(s) added if any
+- [x] Has a commit from less than 2 years ago
 - [ ] Has a **clear** README in English

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,22 @@
-# Added Apache NetBeans as candidate
 <!--- Provide a general summary of your changes in the Title above -->
 
 ## Project URL
-http://netbeans.apache.org
+<!--- The project URL -->
 
 ## Category
-IDE, development
+<!--- Category in Awesome macOS open source applications where the project will be added -->
 
 ## Description
-NetBeans is both an IDE and a platform for development. NetBeans is an integrated development environment (IDE) for Java, PHP, C, C++, HTML5,[4] and JavaScript. The NetBeans Platform is a framework for simplifying the development of Swing desktop applications. The NetBeans IDE bundle for Java SE contains what is needed to start developing NetBeans plugins and NetBeans Platform based applications; no additional SDK is required.
-
+<!--- Describe your changes in detail -->
+ 
 ## Why it should be included to `Awesome macOS open source applications ` (optional)
-NetBeans has been accepted by Apache as a top-level project. It has a stable and engaged development community who have been driving development of the application for many years. There is a supportive community for new and experienced users. All Apache NetBeans source code is freely available to build yourself, or you can download (unsupported) daily development builds.
+
 
 ## Checklist
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
-- [x] Only one project/change is in this pull request
-- [x] Screenshots(s) added if any
-- [x] Has a commit from less than 2 years ago
+- [ ] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
+- [ ] Only one project/change is in this pull request
+- [ ] Screenshots(s) added if any
+- [ ] Has a commit from less than 2 years ago
 - [ ] Has a **clear** README in English

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,22 @@
-# Added Apache NetBeans as candidate
 <!--- Provide a general summary of your changes in the Title above -->
 
 ## Project URL
-http://netbeans.apache.org
+
 
 ## Category
-IDE, development
+
 
 ## Description
-NetBeans is both an IDE and a platform for development. NetBeans is an integrated development environment (IDE) for Java, PHP, C, C++, HTML5,[4] and JavaScript. The NetBeans Platform is a framework for simplifying the development of Swing desktop applications. The NetBeans IDE bundle for Java SE contains what is needed to start developing NetBeans plugins and NetBeans Platform based applications; no additional SDK is required.
+
 
 ## Why it should be included to `Awesome macOS open source applications ` (optional)
-NetBeans has been accepted by Apache as a top-level project. It has a stable and engaged development community who have been driving development of the application for many years. There is a supportive community for new and experienced users. All Apache NetBeans source code is freely available to build yourself, or you can download (unsupported) daily development builds.
+
 
 ## Checklist
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
-- [x] Only one project/change is in this pull request
-- [x] Screenshots(s) added if any
-- [x] Has a commit from less than 2 years ago
+- [ ] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
+- [ ] Only one project/change is in this pull request
+- [ ] Screenshots(s) added if any
+- [ ] Has a commit from less than 2 years ago
 - [ ] Has a **clear** README in English

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,22 +1,23 @@
+# Added Apache NetBeans as candidate
 <!--- Provide a general summary of your changes in the Title above -->
 
 ## Project URL
-
+http://netbeans.apache.org
 
 ## Category
-
+IDE, development
 
 ## Description
-
+NetBeans is both an IDE and a platform for development. NetBeans is an integrated development environment (IDE) for Java, PHP, C, C++, HTML5,[4] and JavaScript. The NetBeans Platform is a framework for simplifying the development of Swing desktop applications. The NetBeans IDE bundle for Java SE contains what is needed to start developing NetBeans plugins and NetBeans Platform based applications; no additional SDK is required.
 
 ## Why it should be included to `Awesome macOS open source applications ` (optional)
-
+NetBeans has been accepted by Apache as a top-level project. It has a stable and engaged development community who have been driving development of the application for many years. There is a supportive community for new and experienced users. All Apache NetBeans source code is freely available to build yourself, or you can download (unsupported) daily development builds.
 
 ## Checklist
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-- [ ] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
-- [ ] Only one project/change is in this pull request
-- [ ] Screenshots(s) added if any
-- [ ] Has a commit from less than 2 years ago
+- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
+- [x] Only one project/change is in this pull request
+- [x] Screenshots(s) added if any
+- [x] Has a commit from less than 2 years ago
 - [ ] Has a **clear** README in English

--- a/applications.json
+++ b/applications.json
@@ -1,6 +1,24 @@
 {
     "applications": [
-        {
+		{
+			"short_description": "Apache NetBeans is an IDE, Tooling Platform and Application Framework suitable for development in Java, JavaScript, PHP, HTML5, CSS, and more.",
+			"categories": [
+				"ide",
+				"development"
+			],
+			"repo_url": "https://github.com/apache/netbeans",
+			"title": "Apache Netbeans",
+			"icon_url": "http://netbeans.apache.org/images/apache-netbeans.svg",
+			"screenshots": [
+				"https://www.dropbox.com/s/r9ewe87xer4nypj/netbeans_dark.png?dl=0",
+				"https://www.dropbox.com/s/qs2gh43lrsbdkid/netbeans_light.png?dl=0"
+			],
+			"official_site": "http://netbeans.apache.org",
+			"languages": [
+				"java"
+			]
+		},
+		{
             "short_description": "PlayStatus is a macOS app that allows the control of Spotify and iTunes music playback from the menu bar.",
             "categories": [
                 "audio",


### PR DESCRIPTION
# Added Apache NetBeans as candidate
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
http://netbeans.apache.org

## Category
IDE, development

## Description
NetBeans is both an IDE and a platform for development. NetBeans is an integrated development environment (IDE) for Java, PHP, C, C++, HTML5,[4] and JavaScript. The NetBeans Platform is a framework for simplifying the development of Swing desktop applications. The NetBeans IDE bundle for Java SE contains what is needed to start developing NetBeans plugins and NetBeans Platform based applications; no additional SDK is required.

## Why it should be included to `Awesome macOS open source applications ` (optional)
NetBeans has been accepted by Apache as a top-level project. It has a stable and engaged development community who have been driving development of the application for many years. There is a supportive community for new and experienced users. All Apache NetBeans source code is freely available to build yourself, or you can download (unsupported) daily development builds.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [ ] Has a **clear** README in English
