### PR TITLE
Add `deadbolt` under Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,6 +528,7 @@ You can see in which language an app is written. Currently there are following l
 ### Security
 - [Cloaker](https://github.com/spieglt/cloaker) - simple drag-and-drop, password-based file encryption. ![rust_icon] 
 - [Cryptomator](https://github.com/cryptomator/cryptomator) - Multi-platform transparent client-side encryption of your files in the cloud. ![java_icon] 
+- [Deadbolt](https://github.com/alichtman/deadbolt) - The easiest file encryption app you'll ever use.
 - [LuLu](https://github.com/objective-see/LuLu) - LuLu is macOS firewall application that aims to block unauthorized (outgoing) network traffic.  ![objective_c_icon] 
 - [Swifty](https://github.com/swiftyapp/swifty) - Free and offline password manager.  ![javascript_icon] 
 - [stronghold](https://github.com/alichtman/stronghold) - Easily configure macOS security settings from the terminal.  ![python_icon] 


### PR DESCRIPTION
## Project URL

[Deadbolt](https://github.com/alichtman/deadbolt

## Category

Security

## Description

Cross-platform encryption app with intuitive user interface and secure defaults.
 
## Why it should be included to `Awesome macOS open source applications`

It's awesome, open source, and a macOS app. 

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [ ] Only one project/change is in this pull request
- [ ] Screenshots(s) added if any
- [ ] Has a commit from less than 2 years ago
- [ ] Has a **clear** README in English
