### PR TITLE
Window-Manager Yabai

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -7030,6 +7030,23 @@
             ]
         },
         {
+          "short_description": "A tiling window manager for macOS based on binary space partitioning.",
+          "categories": [
+              "window-management"
+          ],
+          "repo_url": "https://github.com/koekeishiya/yabai",
+          "title": "Yabai",
+          "icon_url": "https://raw.githubusercontent.com/koekeishiya/yabai/master/assets/banner/banner.svg?sanitize=true",
+          "screenshots": [
+            "https://raw.githubusercontent.com/koekeishiya/yabai/master/assets/screenshot.png"
+          ],
+          "official_site": "",
+          "languages": [
+              "c",
+              "objective_c"
+          ]
+        },
+        {
             "short_description": "Teach your kids the alphabet and how to type.",
             "categories": [
                 "other"


### PR DESCRIPTION
This PR adds the tiling window manager Yabai to the application-list.

## Project URL
https://github.com/koekeishiya/yabai

## Category
window-management

## Description
This PR creates a JSON Entry in the `applications.json` file.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
I personally like tiling window managers, because they help me organise (it's more the way I think). Thus, I would like to give this project some credit by this PR.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [ ] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English
