### PR TITLE
Add Nocturnal

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -7818,6 +7818,21 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "short_description": "Menu bar app featuring darker than dark dimming, Night Shift fine tuning, and the ability to turn off TouchBar on MacBook Pro. ",
+            "categories": [
+                "utilities",
+                "menubar"
+            ],
+            "repo_url": "https://github.com/joshjon/nocturnal",
+            "title": "Nocturnal",
+            "icon_url": "https://raw.githubusercontent.com/joshjon/nocturnal/master/Nocturnal/Assets.xcassets/AppIcon.appiconset/Icon-App-256x256%401x.png",
+            "screenshots": ["https://raw.githubusercontent.com/joshjon/nocturnal/master/Docs/Images/Nocturnal-Screenshot.png"],
+            "official_site": "",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Project URL
https://github.com/joshjon/nocturnal

## Category

- `utilities`
- `menubar`

## Description
Nocturnal is an open-source app that is great for people who have sensitive eyes. It lets you apply darker than dark dimming, fine tune Night Shift temperature, completely turn off TouchBar on Macbook Pro, and supports multi-screen setups.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
