### PR TITLE
Add CoreLocationCLI

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -7818,6 +7818,21 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "short_description": "Get the physical location of your device and prints it to standard output",
+            "categories": [
+                "utilities"
+            ],
+            "repo_url": "https://github.com/fulldecent/corelocationcli",
+            "title": "CoreLocationCLI",
+            "screenshots": [
+                "https://cloud.githubusercontent.com/assets/382183/25063655/52c11234-221d-11e7-81fb-0f8712dac393.gif"
+            ],
+            "official_site": "https://github.com/fulldecent/corelocationcli",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }

--- a/applications.json
+++ b/applications.json
@@ -7829,7 +7829,7 @@
             "screenshots": [
                 "https://cloud.githubusercontent.com/assets/382183/25063655/52c11234-221d-11e7-81fb-0f8712dac393.gif"
             ],
-            "official_site": "https://github.com/fulldecent/corelocationcli",
+            "official_site": "",
             "languages": [
                 "swift"
             ]


### PR DESCRIPTION
## Project URL
CoreLocationCLI

## Category
Utility

## Description
CoreLocationCLI gets the physical location of your device and prints it to standard output. If you move it can also print your updated location.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
In case you forget where you are.

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
