### PR TITLE
Add macOS GateKeeper Helper

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -7929,6 +7929,25 @@
             "languages": [
                 "swift"
             ]
-        }
+        },
+	{
+            "repo_url" : "https://github.com/wynioux/macOS-GateKeeper-Helper",
+            "official_site" : "https://github.com/wynioux/macOS-GateKeeper-Helper",
+            "title" : "macOS GateKeeper Helper",
+            "icon_url": "",
+            "screenshots" : [
+              "https://raw.githubusercontent.com/wynioux/macOS-GateKeeper-Helper/master/screenshot.png"
+            ],
+            "short_description" : "Simple macOS GateKeeper script. It helps you to control your GateKeeper.",
+            "languages" : [
+              "shell"
+            ],
+            "categories" : [
+              "system",
+	      "utilities",
+	      "security",
+	      "terminal"
+            ]
+        },
     ]
 }

--- a/applications.json
+++ b/applications.json
@@ -7932,7 +7932,7 @@
         },
 	{
             "repo_url" : "https://github.com/wynioux/macOS-GateKeeper-Helper",
-            "official_site" : "https://github.com/wynioux/macOS-GateKeeper-Helper",
+            "official_site" : "",
             "title" : "macOS GateKeeper Helper",
             "icon_url": "",
             "screenshots" : [


### PR DESCRIPTION
This is a simple useful tool for users which allow you to do the following:
Show GateKeeper Status.
Enable GateKeeper.
Disable GateKeeper.
Remove app from GateKeeper quarantine.
Self-sign the app.

<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/wynioux/macOS-GateKeeper-Helper

## Category
System, Utilities, Security and Terminal

## Description
Add Add macOS GateKeeper Helper in applications.json
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
It helps you to control your GateKeeper.

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [ ] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
