### PR TITLE
Add Karaoke Forever

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -7985,7 +7985,7 @@
 	            "terminal"
             ]
         },
-	      {
+	{
             "repo_url" : "https://github.com/bhj/karaoke-forever",
             "official_site" : "https://www.karaoke-forever.com",
             "title" : "Karaoke Forever",

--- a/applications.json
+++ b/applications.json
@@ -7959,7 +7959,7 @@
             "icon_url": "https://github.com/maoyama/GitBlamePR/blob/master/GitBlamePR/Assets.xcassets/AppIcon.appiconset/gitblamepr1024.png",
             "screenshots": [
                "https://github.com/maoyama/GitBlamePR/blob/master/Captures/c1.gif",
-               "https://github.com/maoyama/GitBlamePR/blob/master/Captures/c2.gif",
+               "https://github.com/maoyama/GitBlamePR/blob/master/Captures/c2.gif"
             ],
             "official_site": "",
             "languages": [
@@ -7983,6 +7983,23 @@
 	            "utilities",
 	            "security",
 	            "terminal"
+            ]
+        },
+	      {
+            "repo_url" : "https://github.com/bhj/karaoke-forever",
+            "official_site" : "https://www.karaoke-forever.com",
+            "title" : "Karaoke Forever",
+            "icon_url": "https://github.com/bhj/karaoke-forever/blob/master/assets/app.png?raw=true",
+            "screenshots" : [
+              "https://github.com/bhj/karaoke-forever/blob/master/docs/assets/images/README.jpg?raw=true"
+            ],
+            "short_description" : "Host awesome karaoke parties where everyone can queue songs from their phone's browser. Plays MP3+G and MP4 with WebGL visualizations.",
+            "languages" : [
+              "javascript"
+            ],
+            "categories" : [
+              "audio",
+              "music"
             ]
         }
     ]


### PR DESCRIPTION
(also removed a trailing comma that made the JSON technically invalid)

## Project URL
https://github.com/bhj/karaoke-forever

## Category
- Audio
- Music

## Description
Host awesome karaoke parties where everyone can queue songs from their phone's browser. Plays MP3+G and MP4 with WebGL visualizations.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
It's been listed over at [awesome-selfhosted](https://github.com/awesome-selfhosted/awesome-selfhosted) for a while but it needs to be on more platform-specific lists as well.

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
