### PR TITLE
Add NoiseBuddy app to the list

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -7984,6 +7984,23 @@
 	            "security",
 	            "terminal"
             ]
+        },
+        {
+            "short_description": "Control the listening mode on your AirPods Pro in the Touch Bar or Menu Bar.",
+            "categories": [
+                "audio",
+                "music",
+                "menubar",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/insidegui/NoiseBuddy",
+            "title": "NoiseBuddy",
+            "icon_url": "https://raw.githubusercontent.com/insidegui/NoiseBuddy/master/screenshots/NoiseBuddyIcon.png",
+            "screenshots": [],
+            "official_site": "",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/insidegui/NoiseBuddy

## Category

- audio
- music
- menubar
- utilities

## Description
Control the listening mode on your AirPods Pro in the Touch Bar or Menu Bar.
 
## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
