### PR TITLE
Sequel ace

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1199,6 +1199,21 @@
             ]
         },
         {
+            "short_description": "Sequel Ace is a fast, easy-to-use Mac database management application for working with MySQL & MariaDB databases.",
+            "categories": [
+                "database"
+            ],
+            "repo_url": "https://github.com/Sequel-Ace/Sequel-Ace",
+            "title": "Sequel Ace",
+            "icon_url": "",
+            "screenshots": [
+            ],
+            "official_site": "",
+            "languages": [
+                "objective_c"
+            ]
+        },
+        {
             "short_description": "Robo 3T (formerly Robomongo) is the free lightweight GUI for MongoDB enthusiasts. ",
             "categories": [
                 "database"

--- a/applications.json
+++ b/applications.json
@@ -1208,7 +1208,7 @@
             "icon_url": "",
             "screenshots": [
             ],
-            "official_site": "",
+            "official_site": "https://sequel-ace.com/",
             "languages": [
                 "objective_c"
             ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/Sequel-Ace/Sequel-Ace

## Category
database

## Description
Adding Sequel Ace to the list since Sequel Pro is not maintained anymore.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [ ] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
