### PR TITLE
Add seashore, image editing for macOS

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -8035,6 +8035,22 @@
               "audio",
               "music"
             ]
+        },
+        {
+            "repo_url" : "https://github.com/robaho/seashore",
+            "official_site" : "https://github.com/robaho/seashore",
+            "title" : "Seashore",
+            "icon_url": "",
+            "screenshots" : [
+              "https://raw.githubusercontent.com/robaho/seashore/master/doc/ss1.png"
+            ],
+            "short_description" : "Easy to use macOS image editing application for the rest of us.",
+            "languages" : [
+              "objective_c"
+            ],
+            "categories" : [
+              "images"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Project URL
https://github.com/robaho/seashore

## Category
images

## Description
It is a simple image editor based on GIMP.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
There are not many images editors listed AFAIK.

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
