### PR TITLE
Add Brooklyn Screensaver

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -5046,6 +5046,23 @@
             ]
         },
         {
+            "short_description": "Screensaver inspired by Apple's Event on October 30, 2018. ",
+            "categories": [
+                "screensaver"
+            ],
+            "repo_url": "https://github.com/pedrommcarrasco/Brooklyn",
+            "title": "Brooklyn",
+            "icon_url": "",
+            "screenshots": [
+                "https://raw.githubusercontent.com/pedrommcarrasco/Brooklyn/master/Design/showcase.gif",
+                "https://raw.githubusercontent.com/pedrommcarrasco/Brooklyn/master/Design/preferenceMenu.png"
+            ],
+            "official_site": "",
+            "languages": [
+                "swift"
+            ]
+        },
+        {
             "short_description": "Apple TV Aerial Screensaver for macOS. ",
             "categories": [
                 "screensaver"


### PR DESCRIPTION
## Project URL
https://github.com/pedrommcarrasco/Brooklyn

## Category
Screensaver

## Description
Screensaver inspired by Apple's Event on October 30, 2018
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
It is a well-made and visually interesting screensaver with 4.2k stars on Github.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
