### PR TITLE
Resolve All Link Warnings

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -4248,7 +4248,7 @@
             "title": "QOwnNotes",
             "icon_url": "https://raw.githubusercontent.com/pbek/QOwnNotes/develop/icons/icon.png",
             "screenshots": [
-               "https://www.qownnotes.org/var/bekerle/storage/images/_aliases/frontpage_slider_full2/qownnotes/frontpage-slider/qownnotes-main-screen-minimal-linux/4706-1-eng-GB/QOwnNotes-Main-Screen-Minimal-Linux.png"
+               "https://www.qownnotes.org/screenshots/screenshot.png"
             ],
             "official_site": "https://www.qownnotes.org/",
             "languages": [
@@ -4639,16 +4639,7 @@
             "repo_url": "https://github.com/klaussinani/ao",
             "title": "Ao",
             "icon_url": "",
-            "screenshots": [
-                "https://klaussinani.tech/ao/media/list-navigation.gif",
-                "https://klaussinani.tech/ao/media/header.png",
-                "https://klaussinani.tech/ao/media/sepia-theme.png",
-                "https://klaussinani.tech/ao/media/black-theme.png",
-                "https://klaussinani.tech/ao/media/dark-theme.png",
-                "https://klaussinani.tech/ao/media/compact-mode.png",
-                "https://klaussinani.tech/ao/media/custom-shortcut-keys.gif",
-                "https://klaussinani.tech/ao/media/scalable-interface.gif"
-            ],
+            "screenshots": [],
             "official_site": "",
             "languages": [
                 "javascript",
@@ -5565,7 +5556,7 @@
             "title": "KeepingYouAwake",
             "icon_url": "",
             "screenshots": [
-                "https://raw.githubusercontent.com/newmarcel/KeepingYouAwake/master/Extras/Screenshot.jpg"
+                "https://raw.githubusercontent.com/newmarcel/KeepingYouAwake/master/Extras/Screenshot@2x.jpg"
             ],
             "official_site": "",
             "languages": [
@@ -6261,20 +6252,6 @@
             "official_site": "",
             "languages": [
                 "javascript"
-            ]
-        },
-        {
-            "short_description": "The Unarchiver is an Objective-C application for uncompressing archive files. ",
-            "categories": [
-                "utilities"
-            ],
-            "repo_url": "https://bitbucket.org/kosovan/theunarchiver/src ",
-            "title": "The Unarchiver",
-            "icon_url": "http://wakaba.c3.cx/images/unarchiver_icon.png",
-            "screenshots": [],
-            "official_site": "https://theunarchiver.com",
-            "languages": [
-                "objective_c"
             ]
         },
         {
@@ -7584,7 +7561,7 @@
             "title": "Spotter",
             "icon_url": "https://github.com/spotter-application/spotter/blob/master/preview/icon.png",
             "screenshots": [],
-            "official_site": "https://github.com/spotter-application/spotter",
+            "official_site": "",
             "languages": [
                 "type_script",
                 "swift"
@@ -7613,12 +7590,12 @@
             ],
             "repo_url": "https://github.com/khrykin/StrategrDesktop",
             "title": "Strategr",
-            "icon_url": "https://khrykin.github.io/strategr/resources/Strategr.png",
+            "icon_url": "https://khrykin.github.io/StrategrDesktop/assets/resources/Strategr.png",
             "screenshots": [
                "https://camo.githubusercontent.com/0aab0a8a9be68c3f98628a5c7dc2a09da176ea7a/68747470733a2f2f6b6872796b696e2e6769746875622e696f2f73747261746567722f7265736f75726365732f6d61635f6d61696e5f6f726967696e616c2e706e67",
                "https://camo.githubusercontent.com/1e9cc6df1bafd86c7f619cca3d4b3c30f9917398/68747470733a2f2f6b6872796b696e2e6769746875622e696f2f73747261746567722f7265736f75726365732f6d61635f626c61636b5f6d61696e2e706e67"
             ],
-            "official_site": "https://khrykin.github.io/strategr/",
+            "official_site": "https://khrykin.github.io/StrategrDesktop/",
             "languages": [
                 "cpp",
                 "objective_c"


### PR DESCRIPTION
## Description
- Ao: the website hosting the screenshots has gone away
- KeepingYouAwake: was missing a @2 at the end of the filename
- The Unarchiver: No open source repo. Actually a closed source MacPaw product.
- Spotter: Put repo link in the wrong category
- Strategr: Moved to StrategrDesktop page of khrykin.github.io
- QOwnNotes: Screenshot location moved on website

## Why it should be included to `Awesome macOS open source applications `
Every pull request is receiving a message saying these issues needed to be resolved.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
