### PR TITLE
Fix Itsycal mistake in title

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -8055,7 +8055,7 @@
                 "productivity"
             ],
             "repo_url": "https://github.com/sfsam/Itsycal",
-            "title": "Hidden Bar",
+            "title": "Itsycal",
             "icon_url": "",
             "screenshots": [
                "https://www.mowglii.com/itsycal/itsycalbanner2@2x.png"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This is a followup PR to fix an issue in my recently merged PR that added Itsycal: https://github.com/serhii-londar/open-source-mac-os-apps/pull/585. I forgot to change the title after doing my Hidden Bar PR.