### PR TITLE
Add RedditOS

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -5434,7 +5434,7 @@
              "title": "RedditOS",
              "icon_url": "",
              "screenshots": [
-                 "https://github.com/Dimillian/RedditOS/raw/master/Images/image1.png?"
+                 "https://raw.githubusercontent.com/Dimillian/RedditOS/master/Images/image1.png"
              ],
              "official_site": "",
              "languages": [

--- a/applications.json
+++ b/applications.json
@@ -5425,6 +5425,22 @@
                 "swift"
             ]
         },
+	{
+             "short_description": "A SwiftUI Reddit client for macOS. ",
+             "categories": [
+                 "social-networking"
+             ],
+             "repo_url": "https://github.com/Dimillian/RedditOS",
+             "title": "RedditOS",
+             "icon_url": "",
+             "screenshots": [
+                 "https://github.com/Dimillian/RedditOS/raw/master/Images/image1.png?"
+             ],
+             "official_site": "",
+             "languages": [
+                 "swift"
+             ]
+        },
         {
             "short_description": "Perpetual artwork streaming app. ",
             "categories": [


### PR DESCRIPTION
Add RedditOS macOS project.

## Project URL
https://github.com/Dimillian/RedditOS

## Category
Social Networking

## Description

A SwiftUI Reddit client for macOS.
This is bleeding edge, you need macOS Big Sur beta and Xcode 12 beta.


## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
