### PR TITLE
Add Duplicate Finder

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -8102,6 +8102,23 @@
             "categories" : [
               "images"
             ]
+        },
+        {     
+            "repo_url" : "https://github.com/powerwolf543/DuplicateFinder",
+            "official_site" : "",
+            "title" : "Duplicate Finder",
+            "icon_url": "",
+            "screenshots" : [
+              "https://user-images.githubusercontent.com/16394562/94992308-bc3bf000-05bb-11eb-95a9-907ec334c660.png"
+            ],
+            "short_description" : "It's a useful tool that would help you to find all duplicate files which have the same names in the specific folder.",
+            "languages" : [
+              "swift"
+            ],
+            "categories" : [
+              "finder",
+              "utilities"
+            ]
         }
     ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/powerwolf543/DuplicateFinder

## Category
- `finder`
- `utilities`

## Description
It's a useful tool that would help you to find all duplicate files which have the same names in the specific folder.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
