### PR TITLE
Add Plain Pasta

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -8102,6 +8102,20 @@
             "categories" : [
               "images"
             ]
+        },
+        {
+            "short_description": "Plaintextify your clipboard",
+            "categories": [
+                "utilities"
+            ],
+            "repo_url": "https://github.com/hisaac/PlainPasta/",
+            "title": "Plain Pasta",
+            "icon_url": "https://raw.githubusercontent.com/hisaac/PlainPasta/master/Assets/app-icon-512%402x.png",
+            "screenshots": [],
+            "official_site": "https://hisaac.github.io/PlainPasta/",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Project URL

- GitHub: https://github.com/hisaac/PlainPasta/
- Webpage: https://hisaac.github.io/PlainPasta/

## Category

Utilities

## Description

- Fix indentation in CONTRIBUTING.md
- Add Plain Pasta to applications.json

## Why it should be included to `Awesome macOS open source applications ` (optional)

This is a little Swift app that I've open-sourced. Everyone who uses it seems to like it, and I'd love for more people to check it out.

## Checklist

- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://g$
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English