### PR TITLE
Added ColorSet - Fixes #295

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -8102,6 +8102,25 @@
             "categories" : [
               "images"
             ]
+        },
+	{
+            "short_description": "ColorSet is a macOS utility and framework allowing developers to manage custom interface colors with ease.",
+            "categories": [
+                "development",
+		"graphics"
+            ],
+            "repo_url": "https://github.com/DigiDNA/ColorSet",
+            "title": "ColorSet",
+            "icon_url": "https://imazing.com/img/colorset/colorset-icon-256x256.png",
+            "screenshots": [
+               "https://github.com/DigiDNA/ColorSet/raw/master/Assets/ColorSet.png"
+            ],
+            "official_site": "https://imazing.com/colorset",
+            "languages": [
+                "swift",
+		"c_sharp",
+		"objective_c"
+            ]
         }
     ]
 }

--- a/applications.json
+++ b/applications.json
@@ -8113,7 +8113,7 @@
             "title": "ColorSet",
             "icon_url": "https://imazing.com/img/colorset/colorset-icon-256x256.png",
             "screenshots": [
-               "https://github.com/DigiDNA/ColorSet/raw/master/Assets/ColorSet.png"
+               "https://raw.githubusercontent.com/DigiDNA/ColorSet/master/Assets/ColorSet.png"
             ],
             "official_site": "https://imazing.com/colorset",
             "languages": [


### PR DESCRIPTION
Closes #295 
## Project URL
https://github.com/DigiDNA/ColorSet

## Category
Development, graphics

## Description
ColorSet is a macOS utility and framework allowing developers to manage custom interface colors with ease.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
