### PR TITLE
Add Pi Stats

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -3909,6 +3909,23 @@
             ]
         },
         {
+            "short_description": "macOS app to visualize Pi-hole information.",
+            "categories": [
+                "menubar"
+            ],
+            "repo_url": "https://github.com/Bunn/PiStats",
+            "title": "Pi Stats",
+            "icon_url": "https://raw.githubusercontent.com/Bunn/PiStats/master/images/icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/Bunn/PiStats/master/images/screenshot.png"
+            ],
+            "official_site": "",
+            "languages": [
+                "swift",
+		"objective_c"
+            ]
+        },
+        {
             "short_description": "A minimal and beautiful lyrics app that stays in the menu bar of macOS. ",
             "categories": [
                 "music"


### PR DESCRIPTION
## Project URL
https://github.com/Bunn/PiStats

## Category
Menubar

## Description
macOS app to visualize Pi-hole information.

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
