### PR TITLE
Add JSON Editor

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -2596,6 +2596,22 @@
             ]
         },
         {
+            "short_description": "Dead simple JSON editor using josdejong/jsoneditor",
+            "categories": [
+                "json"
+            ],
+            "repo_url": "https://github.com/fand/json-editor-app",
+            "title": "JSON Editor",
+            "icon_url": "https://user-images.githubusercontent.com/1403842/73547507-70f89d00-4482-11ea-9559-545e5f82459a.png",
+            "screenshots": [
+                "https://user-images.githubusercontent.com/1403842/73547401-2ecf5b80-4482-11ea-8b03-753c1621c116.png"
+            ],
+            "official_site": "",
+            "languages": [
+                "typescript"
+            ]
+        },
+        {
             "short_description": "Tree-structured markdown editor for macOS, Windows, and Linux. ",
             "categories": [
                 "markdown"


### PR DESCRIPTION
## Project URL
https://github.com/fand/json-editor-app

## Category
Editors -> JSON

## Description
Dead simple JSON editor using josdejong/jsoneditor.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
This is a simple JSON editor.
I usually use it in masOS. I created a PR to add it here because it's useful.

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
