### PR TITLE
Add Bitwarden Menu

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -6248,6 +6248,22 @@
             ]
         },
         {
+            "short_description": "Bitwarden Passwort Manager in your menu bar",
+            "categories": [
+                "utilities"
+            ],
+            "repo_url": "https://github.com/jnsdrtlf/bitwarden-menubar",
+            "title": "Bitwarden Menu",
+            "icon_url": "https://github.com/jnsdrtlf/bitwarden-menubar/blob/main/Bitwarden/Assets.xcassets/AppIcon.appiconset/icon%40128.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/jnsdrtlf/bitwarden-menubar/main/artwork/screenshot.png"
+            ],
+            "languages": [
+                "type_script",
+		"swift"
+            ]
+        },
+        {
             "short_description": "Receive native push notifications on macOS, Windows and Linux. ",
             "categories": [
                 "utilities"


### PR DESCRIPTION
Add an entry for [Bitwarden Menu](https://github.com/jnsdrtlf/bitwarden-menubar), a simple application for macOS that puts the Bitwarden Browser Extension right into your menu bar.

<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/jnsdrtlf/bitwarden-menubar

## Category
Utilities

## Description
Simple application for macOS that puts the Bitwarden Browser Extension right into your menu bar.

## Checklist
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English
