### PR TITLE
Add RocketChat

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -8155,6 +8155,22 @@
               ]
         },
         {
+            "repo_url" : "https://github.com/RocketChat/Rocket.Chat.Electron",
+            "official_site" : "https://rocket.chat/",
+            "title" : "RocketChat",
+            "icon_url": "https://rocket.chat/wp-content/uploads/2020/09/cropped-Logo-Simbolo-Vermelho-PNG-e1599852240317-192x192.png",
+            "screenshots" : [
+              "https://rocket.chat/wp-content/uploads/2020/07/devices-screens-1536x866.png"
+            ],
+            "short_description" : "Free open source chat system for teams. An alternative to Slack that can also be self hosted.",
+            "languages" : [
+              "javascript"
+            ],
+            "categories" : [
+              "chat"
+            ]
+        },
+        {
             "short_description": "Plaintextify your clipboard",
             "categories": [
                 "utilities"


### PR DESCRIPTION
Adds Rocket Chat

## Project URL
https://github.com/RocketChat/Rocket.Chat.Electron

## Category
Chat

## Description
Free open source chat system for teams. An alternative to Slack that can also be self hosted.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
Good open source projects including meteor server, electron apps and reactive-native apps.

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
