### PR TITLE
Add Wineskin server

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -8184,6 +8184,23 @@
               "finder",
               "utilities"
             ]
+        },
+        {     
+            "repo_url" : "https://github.com/Gcenx/WineskinServer",
+            "official_site" : "https://www.codeweavers.com/",
+            "title" : "Wineskin Server",
+            "icon_url": "",
+            "screenshots" : [
+              "https://user-images.githubusercontent.com/16394562/94992308-bc3bf000-05bb-11eb-95a9-907ec334c660.png"
+            ],
+            "short_description" : "Wineskin Unofficial wrapper that gives you ability to run win32/win64 apps on macOS via built-in Wine.",
+            "languages" : [
+              "c",
+              "cpp"
+            ],
+            "categories" : [
+              "other"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Wineskin server

## Project URL
https://www.codeweavers.com/crossover

## Category
other

## Description
Added Wineskin server - gives you ability to run win32/win64 apps. Even on macOS Catalina and Big Sur due to wine32on64 layer.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
Because people can wish to run win32/win64 apps like on Linux, and also this gives you ability to run Dx11 games like Witcher 3 on GTA V due to MoltenVK layer. Not tested for now.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [ ] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
