### PR TITLE
Add Is It Private

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -8104,6 +8104,22 @@
             ]
           },
           {
+            "short_description": "A Safari Extension providing a toolbar icon that changes its visual appearance if Private Browsing is enabled.",
+            "categories": [
+                "extensions"
+            ],
+            "repo_url": "https://github.com/ffittschen/IsItPrivate",
+            "title": "Is It Private?",
+            "icon_url": "https://github.com/ffittschen/IsItPrivate/raw/master/Assets/AppIcon.png",
+            "screenshots": [
+               "https://github.com/ffittschen/IsItPrivate/raw/master/Assets/Screenshot.png"
+            ],
+            "official_site": "https://florian.codes/projects/is-it-private/",
+            "languages": [
+                "English"
+            ]
+          },
+          {
             "short_description": "An ultra-light MacOS utility that helps hide menu bar icons",
             "categories": [
                 "menubar"

--- a/applications.json
+++ b/applications.json
@@ -8116,7 +8116,7 @@
             ],
             "official_site": "https://florian.codes/projects/is-it-private/",
             "languages": [
-                "English"
+                "swift"
             ]
           },
           {


### PR DESCRIPTION
## Project URL
https://github.com/ffittschen/IsItPrivate

## Category
Extensions

## Description
Adds the _Is It Private?_ Safari extension.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
It is built as [Safari App Extension](https://developer.apple.com/documentation/safariservices/safari_app_extensions), which can be interesting for other developers who want to create a Safari extension.

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
