### PR TITLE
Add ThenGenerator

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -8416,6 +8416,23 @@
  	      	"music",
                	"video"
              ]
-         }
+         },
+         {
+            "repo_url" : "https://github.com/87kangsw/ThenGenerator",
+            "official_site" : "",
+            "title" : "ThenGenerator",
+            "icon_url": "https://raw.githubusercontent.com/87kangsw/ThenGenerator/main/.github/images/icon_512x512.png",
+            "screenshots" : [],
+            "short_description" : "Xcode Source Editor Extension for 'Then'",
+            "languages" : [
+                "swift"
+            ],
+            "categories" : [
+                "extensions",
+                "productivity",
+                "utilities"
+            ]
+        }
+
     ]
 }

--- a/applications.json
+++ b/applications.json
@@ -8422,7 +8422,9 @@
             "official_site" : "",
             "title" : "ThenGenerator",
             "icon_url": "https://raw.githubusercontent.com/87kangsw/ThenGenerator/main/.github/images/icon_512x512.png",
-            "screenshots" : [],
+            "screenshots" : [
+                "https://github.com/87kangsw/ThenGenerator/raw/main/.github/images/property.png"
+            ],
             "short_description" : "Xcode Source Editor Extension for 'Then'",
             "languages" : [
                 "swift"


### PR DESCRIPTION
## Project URL
https://github.com/87kangsw/ThenGenerator

## Category
extensions, productivity, utilities

## Description
Xcode Source Editor Extension for [Then](https://github.com/devxoul/Then)
 
## Why it should be included to `Awesome macOS open source applications ` (optional)


## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
