### PR TITLE
Add SimpleLocalize CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ You can see in which language an app is written. Currently there are following l
 - [ndm](https://github.com/720kb/ndm) - Npm desktop GUI.  ![javascript_icon] 
 - [nodeScratchpad](https://github.com/vsaravind007/nodeScratchpad) - Evaluate Nodejs/JS code snippets from Menubar.  ![swift_icon] 
 - [stts](https://github.com/inket/stts) - macOS app for monitoring the status of cloud services.  ![swift_icon] 
+- [SimpleLocalize CLI](https://github.com/simplelocalize/simplelocalize-cli) - Open source tool for managing i18n keys in software projects. ![swift_icon] 
 
 #### iOS / macOS
 - [AVXCAssets Generator](https://github.com/angelvasa/AVXCAssets-Generator) - Takes path for your assets images and creates appiconset and imageset for you in just one click.  ![swift_icon] 


### PR DESCRIPTION
## Project URL
https://github.com/simplelocalize/simplelocalize-cli

## Category
Web development 

## Description
We use it to translate e-mails which are sent from NodeJS backend. 👍  Open source tool for finding i18n keys in software projects.

## Why it should be included to `Awesome macOS open source applications ` (optional)
It's native macOS app and it's useful in web development

## Checklist
- [ ] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [ ] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
