### PR TITLE
fix invalid json format

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -8408,7 +8408,7 @@
              ],
              "short_description" : "Lightweight, highly configurable media player.",
              "languages" : [
-               "c""
+               "c"
              ],
              "categories" : [
                	"audio",


### PR DESCRIPTION
As the title suggests, this PR fixes the syntax of the json file, cause it had a typo