### PR TITLE
baRSS menu bar news reader

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -8416,6 +8416,24 @@
  	      	"music",
                	"video"
              ]
-         }
+         },
+        {
+            "short_description" : "RSS & Atom feed reader that lives in the system status bar.",
+            "categories" : [
+                "menubar",
+                "news",
+                "utilities"
+            ],
+            "repo_url" : "https://github.com/relikd/barss",
+            "title" : "baRSS – Menu Bar RSS Reader",
+            "icon_url": "https://raw.githubusercontent.com/relikd/baRSS/main/baRSS/Artwork/application-icon.svg",
+            "screenshots" : [
+                "https://raw.githubusercontent.com/relikd/baRSS/main/screenshot.png"
+            ],
+            "official_site" : "",
+            "languages" : [
+                "objective_c"
+            ],
+        }
     ]
 }

--- a/applications.json
+++ b/applications.json
@@ -8408,7 +8408,7 @@
              ],
              "short_description" : "Lightweight, highly configurable media player.",
              "languages" : [
-               "c""
+               "c"
              ],
              "categories" : [
                	"audio",


### PR DESCRIPTION
## Project URL
https://github.com/relikd/barss

## Category
news, menubar, utilities

## Description
RSS & Atom feed reader that lives in the system status bar.

![screenshot](https://raw.githubusercontent.com/relikd/baRSS/main/screenshot.png)
 
## Why it should be included to `Awesome macOS open source applications ` (optional)


## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
