### PR TITLE
Added AltTab

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -7190,6 +7190,25 @@
             ]
         },
         {
+            "short_description": "AltTab brings the power of Windows alt-tab to macOS.",
+            "categories": [
+                "window-management"
+            ],
+            "repo_url": "https://github.com/lwouis/alt-tab-macos",
+            "title": "AltTab",
+            "icon_url": "https://raw.githubusercontent.com/lwouis/alt-tab-macos/44ac1e1012c677572397c1ab12955b9c54b6a175/resources/icons/app/app.svg",
+            "screenshots": [
+                "https://alt-tab-macos.netlify.app/public/demo/1-row.jpg",
+                "https://alt-tab-macos.netlify.app/public/demo/2-rows.jpg",
+                "https://alt-tab-macos.netlify.app/public/demo/windows-theme.jpg"
+            ],
+            "official_site": "https://alt-tab-macos.netlify.app/",
+            "languages": [
+                "swift",
+                "shell"
+            ]
+        },
+        {
             "short_description": "Teach your kids the alphabet and how to type.",
             "categories": [
                 "other"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added [AltTab](https://github.com/lwouis/alt-tab-macos)

## Project URL
https://github.com/lwouis/alt-tab-macos

## Category
Window Management

## Description
**AltTab** brings the power of Windows alt-tab to macOS
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
This application is very handy for developers, is open source, and is actively being updated


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
