### PR TITLE
Adds Unix Epoch Flip Clock under Screensavers

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -8575,6 +8575,22 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "short_description": "Unix epoch timestamp flip clock screensaver.",
+            "categories": [
+                "screensaver"
+            ],
+            "repo_url": "https://github.com/chrstphrknwtn/epoch-flip-clock-screensaver",
+            "title": "Epoch Flip Clock Screensaver",
+            "icon_url": "",
+            "screenshots": [
+                "https://raw.githubusercontent.com/chrstphrknwtn/epoch-flip-clock/master/epochFlipClock.png"
+            ],
+            "official_site": "",
+            "languages": [
+                "objective_c"
+            ]
         }
     ]
 }


### PR DESCRIPTION
This is PR adds an Objective C app under the screensaver section. It is a neat screensaver which shows the current time in the format of the Unix timestamp, on a flip clock. Full credit to  by @chrstphrknwtn

## Project URL
https://github.com/chrstphrknwtn/epoch-flip-clock-screensaver

## Category
Screensaver

## Description
This is a MacOS screensaver by @chrstphrknwtn, which shows the current time in the format of the Unix timestamp, on a flip clock.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
Because it's a neat MacOS app

## Checklist
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English
