### PR TITLE
Add Ferdi

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -857,6 +857,22 @@
             ]
         },
         {
+            "short_description": "Ferdi is messaging application for services like WhatsApp, Slack, Messenger and many more. It started off as a hard-fork of Franz, but has now surpassed it in features.",
+            "categories": [
+                "chat"
+            ],
+            "repo_url": "https://github.com/getferdi/ferdi",
+            "title": "Ferdi",
+            "icon_url": "https://getferdi.com/wp-content/uploads/sites/4/2021/08/social-preview.png",
+            "screenshots": [
+                "https://getferdi.com/wp-content/uploads/sites/4/2021/08/laptop-1.png"
+            ],
+            "official_site": "https://getferdi.com/",
+            "languages": [
+                "javascript"
+            ]
+        },
+        {
             "short_description": "Franz is messaging application for services like WhatsApp, Slack, Messenger and many more. ",
             "categories": [
                 "chat"
@@ -4008,7 +4024,7 @@
             "languages": [
                 "swift"
             ]
-        },    
+        },
         {
             "short_description": "A minimal and beautiful lyrics app that stays in the menu bar of macOS. ",
             "categories": [
@@ -8333,7 +8349,7 @@
                 "java"
             ]
         },
-        {     
+        {
             "repo_url" : "https://github.com/powerwolf543/DuplicateFinder",
             "official_site": "",
             "title" : "Duplicate Finder",
@@ -8417,7 +8433,7 @@
                 "c"
             ]
         },
-        {     
+        {
             "repo_url" : "https://github.com/doekman/osagitfilter",
             "official_site" : "",
             "title" : "osagitfilter",
@@ -8432,7 +8448,7 @@
                 "git"
             ]
         },
-        {     
+        {
             "repo_url" : "https://github.com/mpv-player/mpv",
             "official_site" : "https://mpv.io",
             "title" : "MPV",
@@ -8467,7 +8483,7 @@
                 "swift"
             ]
         },
-        {     
+        {
             "repo_url" : "https://github.com/b3z/reventlou",
             "official_site" : "",
             "title" : "reventlou",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
getferdi.com

## Category
chat

## Description
Ferdi is messaging application for services like WhatsApp, Slack, Messenger and many more. It started off as a hard-fork of Franz, but has now surpassed it in features.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
