### PR TITLE
Replace Visual Studio Code with VSCodium

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -3301,17 +3301,15 @@
             ]
         },
         {
-            "short_description": "Code editor developed by Microsoft. ",
+            "short_description": "Code editor developed by Microsoft without proprietary components.",
             "categories": [
                 "ide"
             ],
-            "repo_url": "https://github.com/Microsoft/vscode",
-            "title": "Visual Studio Code",
+            "repo_url": "https://github.com/VSCodium/vscodium",
+            "title": "VSCodium",
             "icon_url": "",
-            "screenshots": [
-                "https://cloud.githubusercontent.com/assets/11839736/16642200/6624dde0-43bd-11e6-8595-c81885ba0dc2.png"
-            ],
-            "official_site": "",
+            "screenshots": [],
+            "official_site": "https://vscodium.com",
             "languages": [
                 "type_script"
             ]


### PR DESCRIPTION
This PR swaps VSCode with VSCodium, a fully FOSS alternative to Visual Studio Code.

## Project URL
[VSCodium](https://vscodium.com/)

## Category
IDE

## Description
This replaces Visual Studio Code with VSCodium in applications.json.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
VSCodium is to VSCode as Chromium is to Chrome. Visual Studio Code includes non-FOSS components (most notably telemetry and branding) that VSCodium does not have. Beyond that, they are functionally identical to one another.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [ ] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
