### PR TITLE
Adding Stringz

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,5 +1,24 @@
 {
     "applications": [
+           {
+            "short_description": "A lightweight and powerful editor for localizing iOS, macOS, tvOS, and watchOS applications.",
+            "categories": [
+                "development",
+                "ios--macos",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/mohakapt/Stringz",
+            "title": "Stringz",
+            "icon_url": "https://raw.githubusercontent.com/mohakapt/Stringz/main/Resources/app_icon.png",
+            "screenshots": [
+               "https://raw.githubusercontent.com/mohakapt/Stringz/main/Resources/hero_dark.png",
+               "https://raw.githubusercontent.com/mohakapt/Stringz/main/Resources/hero_light.png"
+            ],
+            "official_site": "",
+            "languages": [
+                "swift"
+            ]
+        },
         {
             "short_description": "Tiny stocks watcher for the menu bar.",
             "categories": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
[Stringz](https://github.com/mohakapt/Stringz)

## Category
Development, iOS/macOS, Utilities

## Description
Stringz greatly simplifies localizing your Xcode apps (iOS, macOS, tvOS, and watchOS) by introducing a powerful editor for all localizable files in your project. It even imports strings from storyboard and xib files saving you a lot of time and effort finding and matching elementIds in your storyboards. Stringz also supports localizing your Info.plist file so you can easily translate your app name and permission descriptions.
Stringz will also highlight missing translations and warn you about duplicate values and has many more useful features that take a painful and tedious task like localizing your app and convert it to an easy and simple task.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
The app is a life saver when working on international projects, It makes localizing Xcode projects easy and intuitive.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
