### PR TITLE
Removed Mockup Generator as the project was deleted.

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -2393,23 +2393,6 @@
             ]
         },
         {
-            "short_description": "Mockup Generator is a macOS app built with AngularJS/Electron that sits in your menu bar allowing you to capture screenshots of your favourite websites and wrap them in device mock-ups. ",
-            "categories": [
-                "web-development"
-            ],
-            "repo_url": "https://github.com/andypotts/mockup-generator",
-            "title": "Mockup Generator",
-            "icon_url": "",
-            "screenshots": [
-                "https://raw.githubusercontent.com/andypotts/mockup-generator/master/screenshot2.png",
-                "https://raw.githubusercontent.com/andypotts/mockup-generator/master/screenshot1.png"
-            ],
-            "official_site": "",
-            "languages": [
-                "javascript"
-            ]
-        },
-        {
             "short_description": "Npm desktop GUI. ",
             "categories": [
                 "web-development"


### PR DESCRIPTION
## Project URL
N/A

## Category
N/A

## Description
I removed the Mockup Generator, as the project was deleted from Github. It's certainly possible there's a replacement/fork of it, so it's probably a good idea to look for one.

Also, sorry if I'm doing anything wrong, I don't have much experience with pull requests or commits.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
N/A

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [ ] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [ ] Has a **clear** README in English (Don't think this applies?)
