### PR TITLE
Add Chess.app

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -8865,6 +8865,22 @@
             "languages": [
                 "javascript"
             ]
-        }
+        },
+		{
+			"short_description": "The chess app that comes with macOS.",
+			"categories": [
+				"games"
+			],
+			"repo_url": "https://opensource.apple.com/source/Chess/Chess-410.4.1/",
+			"title": "Chess",
+			"icon_url": "https://opensource.apple.com/source/Chess/Chess-410.4.1/MBChess/Images.xcassets/AppIcon.appiconset/icon_256x256.png",
+			"screenshots": [
+			   "https://upload.wikimedia.org/wikipedia/commons/8/83/Chess_screenshot.png",
+			],
+			"official_site": "https://apple.com",
+			"languages": [
+				"objective-c"
+			]
+		}
     ]
 }


### PR DESCRIPTION
## Project URL
https://opensource.apple.com/source/Chess/Chess-410.4.1/

## Category
Games

## Description
Added the default Chess.app app that comes with macOS.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
Because it's cool that Apple open sourced this, and it's still included with macOS. Most people don't know that it's open source.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any (Couldn't find any from Apple, got one from wikipedia)
- [x] Has a commit from less than 2 years ago (The [version from 11.0.1](https://opensource.apple.com/release/macos-1101.html) is different from [11.5](https://opensource.apple.com/release/macos-115.html))
- [ ] Has a **clear** README in English - not really, but there's a help book in Chess.app and it's included with every version of macOS.

