### PR TITLE
Add Pasteboard Viewer

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -8866,6 +8866,22 @@
             "languages": [
                 "javascript"
             ]
+        },
+        {
+            "short_description": "Inspect the system pasteboards.",
+            "categories": [
+                "development"
+            ],
+            "repo_url": "https://github.com/sindresorhus/Pasteboard-Viewer",
+            "title": "Pasteboard Viewer",
+            "icon_url": "https://github.com/sindresorhus/Pasteboard-Viewer/raw/3ab9545e24050a0ca60ab102e9c303345af8da10/Stuff/AppIcon.png",
+            "screenshots": [
+                "https://github.com/sindresorhus/Pasteboard-Viewer/raw/3ab9545e24050a0ca60ab102e9c303345af8da10/Stuff/screenshot1.jpg"
+            ],
+            "official_site": "https://sindresorhus.com/pasteboard-viewer",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL

https://github.com/sindresorhus/Pasteboard-Viewer

## Category

Development

## Description

This is a developer utility that lets you inspect the various system [pasteboards](https://developer.apple.com/documentation/appkit/nspasteboard).
 
## Why it should be included to `Awesome macOS open source applications ` (optional)

When developing an app that has copy/paste functionality, it's very useful to be able to see exactly what is being copied. It can also be useful to debug bugs in app you use. You could even use it to debug copying content from web apps. Let's say your app let the user copy an image, you could use this app to ensure it's copied in the correct format.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
