### PR TITLE
Add LosslessCut

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -8866,6 +8866,23 @@
             "languages": [
                 "javascript"
             ]
+        },
+        {
+            "short_description": "The swiss army knife of lossless video/audio editing without re-encoding.",
+            "categories": [
+                "audio",
+                "video"
+            ],
+            "repo_url": "https://github.com/mifi/lossless-cut",
+            "title": "LosslessCut",
+            "icon_url": "https://raw.githubusercontent.com/mifi/lossless-cut/master/src/icon.svg",
+            "screenshots": [
+                "https://raw.githubusercontent.com/mifi/lossless-cut/master/main_screenshot.jpg"
+            ],
+            "official_site": "https://mifi.no/losslesscut/",
+            "languages": [
+                "javascript"
+            ]
         }
     ]
 }

--- a/categories.json
+++ b/categories.json
@@ -1,5 +1,5 @@
 {
-"categories": 
+"categories":
 [
 {
     "title": "Audio",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/mifi/lossless-cut

## Category
`audio`
`video`

## Description
The swiss army knife of lossless video/audio editing.e
No need to re-encode video or audio and saving disk space.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)

iMovie will re-encode the video that taking a lot of disks space and time.
Sometimes we only need some simple features like cutting or merge video files.
LosslessCut is an excellent option to achieve that.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English
