### PR TITLE
feat: Add AdGuard for Safari

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -8930,6 +8930,22 @@
             ]
         },
         {
+            "short_description": "The most advanced ad blocking extension for Safari",
+            "categories": [
+                "extensions"
+            ],
+            "repo_url": "https://github.com/adguardteam/adguardforsafari",
+            "title": "AdGuard for Safari",
+            "icon_url": "https://camo.githubusercontent.com/b615bb7db1b9bc94567aec6e80a120c6f0bff13d64cc48e962ddf785cc7b18fd/68747470733a2f2f63646e2e616467756172642e636f6d2f7075626c69632f416467756172642f436f6d6d6f6e2f616467756172645f7361666172692e737667",
+            "screenshots": [
+                "https://camo.githubusercontent.com/30d586bf934b280622aeac16949d86bb67184250b2b7902b9ea7fcf53e35ca39/68747470733a2f2f63646e2e616467756172642e636f6d2f7075626c69632f416467756172642f436f6d6d6f6e2f7361666172695f66696c746572732e706e673f"
+            ],
+            "official_site": "https://adguard.com/",
+            "languages": [
+                "javascript"
+            ]
+        },
+        {
             "short_description": "Dynamic Dark Mode is the app you are looking for to power up Dark Mode on macOS Mojave and beyond.",
             "categories": [
                 "games"

--- a/applications.json
+++ b/applications.json
@@ -8940,7 +8940,7 @@
             "screenshots": [
                 "https://camo.githubusercontent.com/30d586bf934b280622aeac16949d86bb67184250b2b7902b9ea7fcf53e35ca39/68747470733a2f2f63646e2e616467756172642e636f6d2f7075626c69632f416467756172642f436f6d6d6f6e2f7361666172695f66696c746572732e706e673f"
             ],
-            "official_site": "https://adguard.com/",
+            "official_site": "https://adguard.com/en/welcome.html",
             "languages": [
                 "javascript"
             ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
<!--- The project URL -->
https://github.com/adguardteam/adguardforsafari

## Category
<!--- Category in Awesome macOS open source applications where the project will be added -->
Extensions

## Description
<!--- Describe your changes in detail -->
 AdGuard is an open-source freemium Safari adblocker.

## Why it should be included to `Awesome macOS open source applications ` (optional)
I had been looking for an equivalent to uBlock Origin for Safari and found AdGuard to be roughly on par with it. It has a point-and-click functionality for zapping ads that slip through, but I've found this to be rare. Overall, it's a great adblocker that also doesn't break functionality on most sites, like YouTube or search engines.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
