### PR TITLE
Add Cyberduck in Sharing-Files section

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -8944,6 +8944,23 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "short_description": "Cyberduck is a libre server and cloud storage browser for Mac and Windows with support for FTP, SFTP, WebDAV, Amazon S3, OpenStack Swift, Backblaze B2, Microsoft Azure & OneDrive, Google Drive and Dropbox.",
+            "categories": [
+                "sharing-files"
+            ],
+            "repo_url": "https://github.com/iterate-ch/cyberduck",
+            "title": "Cyberduck",
+            "icon_url": "https://cdn.cyberduck.io/img/cyberduck-icon-rect-512.png",
+            "screenshots": [
+                "https://cdn.cyberduck.io/img/mac/browser-bookmarks.png",
+                "https://cdn.cyberduck.io/img/mac/browser.png"
+            ],
+            "official_site": "https://cyberduck.io",
+            "languages": [
+                "java"
+            ]
         }
     ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://cyberduck.io

## Category
Sharing Files

## Description
Added Cyberduck in Sharing-Files section. It's a libre server and cloud storage browser for Mac.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
There is no such software in list.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
