### PR TITLE
Add LinkLiar (menubar app for MAC spoofing)

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -3816,6 +3816,22 @@
             ]
         },
         {
+          "short_description": "Keep your MAC address random for privacy (intuitive GUI for ifconfig)",
+          "categories": [
+              "menubar"
+          ],
+          "repo_url": "https://github.com/halo/LinkLiar",
+          "title": "LinkLiar",
+          "icon_url": "",
+          "screenshots": [
+             "https://cdn.rawgit.com/halo/LinkLiar/master/docs/screenshot_3.0.1b.svg"
+          ],
+          "official_site": "https://halo.github.io/LinkLiar",
+          "languages": [
+              "swift"
+          ]
+        },
+        {
             "short_description": "macOS menubar status indicator. ",
             "categories": [
                 "menubar"
@@ -8652,7 +8668,7 @@
             ],
             "official_site": "https://uselinked.com",
             "languages": [
-                "javascript", 
+                "javascript",
                 "vue",
                 "css"
             ]


### PR DESCRIPTION
## Project URL
https://github.com/halo/LinkLiar

## Category
Menubar

(I was considering creating the categories "Networking" and "Privacy". What do you think?)

## Description
LinkLiar is an intuitive open-source macOS status menu application written in Swift to help you spoof the MAC addresses of your Wi-Fi and Ethernet interfaces.
 
## Why it should be included to `Awesome macOS open source applications `
I noticed that [Airpass](https://github.com/alvesjtiago/airpass) (written in JS) is in the list. LinkLiar is similar but runs natively and has a few more features. So, it fits right in.

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any **(hope SVG works?)**
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English

Thank you for your time. This is a useful list! 🤩