### PR TITLE
Add Pika

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -4038,6 +4038,24 @@
             ]
         },
         {
+            "short_description": "Is an easy to use, open-source, native colour picker for macOS.",
+            "categories": [
+                "menubar",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/superhighfives/pika",
+            "title": "Pika",
+            "icon_url": "https://user-images.githubusercontent.com/449385/103492506-4dbd3700-4e23-11eb-97ca-44a959f171c6.png",
+            "screenshots": [
+                "https://user-images.githubusercontent.com/449385/103492507-4e55cd80-4e23-11eb-9366-d31c2bb74030.png"
+            ],
+            "official_site": "https://superhighfives.com/pika",
+            "languages": [
+                "swift",
+                "metal"
+            ]
+        },
+        {
             "short_description": "macOS app to visualize Pi-hole information.",
             "categories": [
                 "menubar"


### PR DESCRIPTION
## Project URL
https://github.com/superhighfives/pika

## Category
Menubar and Utilities

## Description
Pika (pronounced pi·kuh, like picker) is an easy to use, open-source, native colour picker for macOS
 


## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
