### PR TITLE
Add Time to leave

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -5169,6 +5169,25 @@
             ]
         },
         {
+            "short_description": "Log work hours and get notified when it's time to leave the office and start to live.",
+            "categories": [
+                "productivity"
+            ],
+            "repo_url": "https://github.com/thamara/time-to-leave",
+            "title": "Time to Leave",
+            "icon_url": "",
+            "screenshots": [
+                "https://user-images.githubusercontent.com/3754225/94519528-4e549900-0248-11eb-8872-b6fb2d47f43c.jpg",
+                "https://user-images.githubusercontent.com/3754225/94762058-4e79a380-03c4-11eb-8f28-1c480dbf8b5c.png"
+            ],
+            "official_site": "https://timetoleave.app/",
+            "languages": [
+                "javascript",
+                "css",
+                "html"
+            ]
+        },
+        {
             "short_description": "Toggl Desktop app for Windows, Mac and Linux. ",
             "categories": [
                 "productivity"


### PR DESCRIPTION
## Project URL
https://github.com/thamara/time-to-leave

## Category
Productivity

## Description
Time to Leave is a Desktop app for work time management which looks similar to a time-card system. It’s different from other software available as it’s very simple, doesn’t require any database configuration, and focuses on allowing you to control your time. Its premise is to help you manage the time you are working and to notify you when it’s time to leave (hence the name).

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
