### PR TITLE
Added Jamulus

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -8944,6 +8944,23 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "short_description": "Jamulus enables musicians to perform real-time jam sessions over the internet.",
+            "categories": [
+                "audio",
+                "music"
+            ],
+            "repo_url": "https://github.com/jamulussoftware/jamulus",
+            "title": "Jamulus - Internet Jam Session Software",
+            "icon_url": "https://jamulus.io/assets/img/jamulus-icon-2020.svg",
+            "screenshots": [
+               "https://jamulus.io/assets/img/en-screenshots/main-screen-medium.png"
+            ],
+            "official_site": "https://jamulus.io",
+            "languages": [
+                "c"
+            ]
         }
     ]
 }

--- a/applications.json
+++ b/applications.json
@@ -8948,8 +8948,7 @@
         {
             "short_description": "Jamulus enables musicians to perform real-time jam sessions over the internet.",
             "categories": [
-                "audio",
-                "music"
+                "audio"
             ],
             "repo_url": "https://github.com/jamulussoftware/jamulus",
             "title": "Jamulus - Internet Jam Session Software",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/jamulussoftware/jamulus

## Category
Audio

## Description
Jamulus enables musicians to perform real-time jam sessions over the internet.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
It's a pretty amazing piece of software to make music together over the internet. It tackles the latency issue really well.

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
