### PR TITLE
Added KiCad

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -8660,7 +8660,7 @@
         {
             "short_description": "Spotify widget for Notification Center.",
             "categories": [
-                "audio",
+                "audio"
             ],
             "repo_url": "https://github.com/fabiusBile/Spotify4BigSur",
             "title": "Spotify4BigSur",
@@ -8809,7 +8809,7 @@
             "title": "eul",
             "icon_url": "https://raw.githubusercontent.com/gao-sun/eul/master/Resource/Assets.xcassets/eul.imageset/eul%403x.png",
             "screenshots": [
-                "https://user-images.githubusercontent.com/14722250/105626766-f718ab00-5e6c-11eb-9761-661ff85c8faf.jpg",
+                "https://user-images.githubusercontent.com/14722250/105626766-f718ab00-5e6c-11eb-9761-661ff85c8faf.jpg"
             ],
             "official_site": "",
             "languages": [
@@ -8922,7 +8922,7 @@
             "title": "Chess",
             "icon_url": "https://opensource.apple.com/source/Chess/Chess-410.4.1/MBChess/Images.xcassets/AppIcon.appiconset/icon_256x256.png",
             "screenshots": [
-                "https://upload.wikimedia.org/wikipedia/commons/8/83/Chess_screenshot.png",
+                "https://upload.wikimedia.org/wikipedia/commons/8/83/Chess_screenshot.png"
             ],
             "official_site": "https://www.apple.com/",
             "languages": [
@@ -8943,6 +8943,18 @@
             "official_site": "https://apollozhu.github.io/Dynamic-Dark-Mode/",
             "languages": [
                 "swift"
+            ]
+        },
+        {
+            "short_description": "A software suite for electronic design automation.",
+            "categories": [
+                "development"
+            ],
+            "repo_url": "https://gitlab.com/kicad/code/kicad",
+            "official_site": "https://www.kicad.org/",
+            "languages": [
+                "cpp",
+                "c"
             ]
         }
     ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://gitlab.com/kicad/code/kicad

## Category
Development

## Description
Add KiCAD EDA Suite
Also removed unnecessary trailing commas in the json
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
KiCAD is a really useful and well-known tool for designing and exporting electrical schematics and printed circuit boards.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [ ] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English