### PR TITLE
Added TINU by ITzTravelInTime

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,6 +1,32 @@
 {
     "applications": [
         {
+            "short_description": "An open source and easy to use tool for the creation of macOS usb installers.",
+            "categories": [
+                "system",
+                "utilities",
+                "other"
+            ],
+            "repo_url": "https://github.com/ITzTravelInTime/TINU",
+            "title": "TINU",
+            "icon_url": "https://github.com/ITzTravelInTime/TINU/blob/development/TINU/Assets.xcassets/AppIcon.appiconset/custom%20%E2%80%93%201-1024.png",
+            "screenshots": [
+                "https://github.com/ITzTravelInTime/TINU/blob/development/TINU/Screenshots/1.png",
+                "https://github.com/ITzTravelInTime/TINU/blob/development/TINU/Screenshots/2.png",
+                "https://github.com/ITzTravelInTime/TINU/blob/development/TINU/Screenshots/3.png",
+                "https://github.com/ITzTravelInTime/TINU/blob/development/TINU/Screenshots/4.png",
+                "https://github.com/ITzTravelInTime/TINU/blob/development/TINU/Screenshots/5.png",
+                "https://github.com/ITzTravelInTime/TINU/blob/development/TINU/Screenshots/6.png",
+                "https://github.com/ITzTravelInTime/TINU/blob/development/TINU/Screenshots/7.png",
+                "https://github.com/ITzTravelInTime/TINU/blob/development/TINU/Screenshots/8.png"
+            ],
+            "official_site": "https://github.com/ITzTravelInTime/TINU",
+            "languages": [
+                "English",
+                "Italian"
+            ]
+        },
+        {
             "short_description": "A lightweight and powerful editor for localizing iOS, macOS, tvOS, and watchOS applications.",
             "categories": [
                 "development",


### PR DESCRIPTION
Added TINU by ITzTravelInTime

## Project URL
https://github.com/ITzTravelInTime/TINU

## Category
"utilities", "system", "other"

## Description
From TINU's readme: 

TINU, the open tool to create bootable macOS installers.

[TINU Is Not Unibe**t]

This software is intended to be used to create a bootable macOS installer for computers capable of running Apple's macOS, this app is basically a GUI for the createinstallmedia executable that could be found in any macOS installer app from Mavericks up to the latest versions.

Allows you to create easily a macOS install media without messing around with command line stuff and without using disk utility, and also detects and prevents the most common errors with the creation of bootable vanilla macOS installers.

For a description of features or to just learn more here is the link to the repo: https://github.com/ITzTravelInTime/TINU
 
## Why it should be included to `Awesome macOS open source applications ` (optional)

This app is probably one of the very few macOS usb installer creation tools to be fully open source and provviding a very intuitive and simple to use UI, at the same time it works very well and uses just the official apple's createinstallmedia method to create usb installers. This app has been experimented with success on various forums (incl. hackintosh-forum.de and insanelymac.com) and it's very appreciated by it's userbase.

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
