### PR TITLE
Add Inkscape to Images Category

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -8944,6 +8944,22 @@
             "languages": [
                 "swift"
             ]
+        },
+            {
+            "short_description": "Inkscape is a Free and open source vector graphics editor.",
+            "categories": [
+                "images"
+            ],
+            "repo_url": "https://gitlab.com/inkscape/inkscape",
+            "title": "Inkscape",
+            "icon_url": "https://inkscape.org/",
+            "screenshots": [
+               "https://media.inkscape.org/media/resources/file/inkscape-0.48-moonlight-views.png"
+            ],
+            "official_site": "https://inkscape.org/",
+            "languages": [
+                "c++"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Project URL
https://gitlab.com/inkscape/inkscape

## Category
Images

## Description
Adding Inkscape to the Images category
 
## Why it should be included to `Awesome macOS open source applications ` (optional)


## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
