### PR TITLE
Updated EtreCheck URL.

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -5731,7 +5731,7 @@
             "categories": [
                 "system"
             ],
-            "repo_url": "https://github.com/etresoft/EtreCheck",
+            "repo_url": "https://etrecheck.com/",
             "title": "EtreCheck",
             "icon_url": "",
             "screenshots": [],


### PR DESCRIPTION
## Project URL
https://etrecheck.com/

## Category
System

## Description
The current Github link in the list leads to a 404 page, so it seems it was removed from Github. I replaced the old link with the link to EtreCheck's website instead.


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [ ] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [ ] Has a **clear** README in English (I mean I only edited the applications.json so I don't know haha)
