### PR TITLE
Add `micro` text-editor

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -2836,6 +2836,32 @@
             ]
         },
         {
+            "short_description": "A terminal-based text editor that aims to be easy to use and intuitive, while also taking advantage of the capabilities of modern terminals.",
+            "categories": [
+                "text"
+            ],
+            "repo_url": "https://github.com/zyedidia/micro",
+            "title": "micro",
+            "icon_url": "https://raw.githubusercontent.com/zyedidia/micro/master/assets/micro-logo.svg",
+            "screenshots": [
+                "https://micro-editor.github.io/screenshots/micro-monokai.png",
+                "https://micro-editor.github.io/screenshots/micro-one-dark.png",
+                "https://micro-editor.github.io/screenshots/micro-darcula.png",
+                "https://micro-editor.github.io/screenshots/micro-twilight.png",
+                "https://micro-editor.github.io/screenshots/micro-railscast.png",
+                "https://micro-editor.github.io/screenshots/micro-solarized.png",
+                "https://micro-editor.github.io/screenshots/micro-atom-dark.png",
+                "https://micro-editor.github.io/screenshots/micro-gruvbox.png",
+                "https://micro-editor.github.io/screenshots/micro-material.png",
+                "https://micro-editor.github.io/screenshots/micro-gotham.png",
+                "https://micro-editor.github.io/screenshots/micro-zenburn.png"
+            ],
+            "official_site": "https://micro-editor.github.io",
+            "languages": [
+                "go"
+            ]
+        },
+        {
             "short_description": "Plain text editor for macOS with customizable themes. ",
             "categories": [
                 "text"


### PR DESCRIPTION
This PR adds `micro` text-editor to the list.

## Project URL
https://github.com/zyedidia/micro

## Category
Editors/Text

## Description
`applications.json` file has been updated with an entry of `micro` text-editor.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
As its name indicates, `micro` aims to be somewhat of a successor to the `nano` editor by being easy to install and use. It strives to be enjoyable as a full-time editor for people who prefer to work in a terminal, or those who regularly edit files over SSH. It comes as a single, batteries-included, static binary with no dependencies.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
