### PR TITLE
add OnlySwitch

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -9076,6 +9076,23 @@
             ]
         },
         {
+            "short_description": "All-in-One status bar button, hide MacBook Pro's notch, dark mode, AirPods, Shortcuts",
+            "categories": [
+                "menubar",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/jacklandrin/OnlySwitch",
+            "title": "OnlySwitch",
+            "icon_url": "https://www.jacklandrin.com/wp-content/uploads/2021/12/only_switch_256.png",
+            "screenshots": [
+                "https://www.jacklandrin.com/wp-content/uploads/2022/01/onlySwitch_17.png"
+            ],
+            "official_site": "https://www.jacklandrin.com/2021/12/01/onlyswitch/",
+            "languages": [
+                "swift"
+            ]
+        },
+        {
             "short_description": "🏈 Cache CocoaPods for faster rebuild and indexing Xcode project.",
             "categories": [
                 "utilities"


### PR DESCRIPTION
All-in-One status bar button, hide MacBook Pro's notch, dark mode, AirPods, Shortcuts.

## Project URL
https://github.com/jacklandrin/OnlySwitch

## Category
menubar
utilities

## Description
OnlySwitch provides a series of toggle switches to simply your routine work, such as Hiden desktop icons, dark mode and hide ugly notch of new Mackbook Pro. The switches show on your statusbar, you can easily control them. 
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
It can help you control the macOS effortlessly. 

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [ ] Only one project/change is in this pull request
- [ ] Screenshots(s) added if any
- [ ] Has a commit from less than 2 years ago
- [ ] Has a **clear** README in English
