### PR TITLE
Add new finder extension application

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -3069,6 +3069,25 @@
             ]
         },
         {
+            "short_description": "The Quick Symlink is a Finder extension which provides a contextual menu items for the symbolic links (and other links) creation on macOS.",
+            "categories": [
+                "finder",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/ololx/quick-symlink",
+            "title": "Quick Symlink",
+            "icon_url": "",
+            "screenshots": [
+               "https://github.com/ololx/quick-symlink/blob/assets/demo/quick-symlink-demo-2.gif?raw=true",
+               "https://github.com/ololx/quick-symlink/blob/assets/demo/quick-symlink-demo-1.gif?raw=true",
+               "https://github.com/ololx/quick-symlink/blob/assets/demo/quick-symlink-demo-replace-with-link.gif?raw=true" 
+            ],
+            "official_site": "https://ololx.github.io/QUICK_SYMLINK",
+            "languages": [
+                "swift"
+            ]
+        },
+        {
             "short_description": "Turn-based tactical strategy game, featuring both single-player and online multiplayer combat. ",
             "categories": [
                 "games"


### PR DESCRIPTION
Add finder extension which provide the menu items for the crating symlinks and hardlinks

<!--- Provide a general summary of your changes in the Title above -->

## Project URL
<!--- The project URL -->
https://github.com/ololx/quick-symlink

## Category
<!--- Category in Awesome macOS open source applications where the project will be added -->
"categories": [
                "finder",
                "utilities"
            ]

## Description
<!--- Describe your changes in detail -->
The Quick Symlink is a Finder extension which provides a contextual menu items for the symbolic links (and other links) creation on macOS.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
Because it's quite simple but very useful macOS utility.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
