### PR TITLE
add Mana Security app

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -9252,6 +9252,23 @@
             ]
         },
         {
+            "short_description": "Vulnerability Management app for individuals. It helps to keep macOS and installed applications updated.",
+            "categories": [
+                "security"
+            ],
+            "repo_url": "https://github.com/manasecurity/mana-security-app",
+            "title": "Mana Security",
+            "icon_url": "https://avatars.githubusercontent.com/u/66416348",
+            "screenshots": [
+               "https://user-images.githubusercontent.com/13090109/148841509-821fae63-d720-49a1-9584-8ed6b3cdb7ce.png"
+            ],
+            "official_site": "https://manasecurity.com/",
+            "languages": [
+                "javascript",
+                "typescript",
+            ]
+        },
+        {
             "short_description": "Cyberduck is a libre server and cloud storage browser for Mac and Windows with support for FTP, SFTP, WebDAV, Amazon S3, OpenStack Swift, Backblaze B2, Microsoft Azure & OneDrive, Google Drive and Dropbox.",
             "categories": [
                 "sharing-files"


### PR DESCRIPTION
## Project URL

https://github.com/manasecurity/mana-security-app

## Category

Security

## Description

A Vulnerability Management app for individuals. It helps to keep macOS and installed applications updated.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
