### PR TITLE
Add LocationSimulator

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -9267,6 +9267,25 @@
             "languages": [
                 "java"
             ]
-        }
+        },
+        {
+            "short_description": "Application to spoof your iOS or iPhoneSimulator location.",
+            "categories": [
+                "development",
+                "ios--macos",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/Schlaubischlump/LocationSimulator",
+            "title": "LocationSimulator",
+            "icon_url": "https://raw.githubusercontent.com/Schlaubischlump/LocationSimulator/master/LocationSimulator/Assets.xcassets/AppIcon.appiconset/AppIcon_512%402x.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/Schlaubischlump/LocationSimulator/master/Preview/screenshot.png"
+            ],
+            "official_site": "https://schlaubischlump.github.io/LocationSimulator",
+            "languages": [
+                "swift"
+            ]
+        },
+        
     ]
 }


### PR DESCRIPTION
## Project URL
https://github.com/Schlaubischlump/LocationSimulator

## Category
- iOS / macOS
- Development
- Utilities

## Description
Modified the application.json to include LocationSimulator. 
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
OpenSource application to spoof your iOS or iPhoneSimulator location. This is a useful tool for developers since XCode build-in tools for location spoofing are quite limited.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
