### PR TITLE
Added Onionshare to list

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -9249,6 +9249,24 @@
             "languages": [
                 "java"
             ]
+        },
+            {
+            "short_description": Onionshare: Share files anonymously over TOR,
+            "categories": [
+                Productivity,
+                Sharing Files
+            ],
+            "repo_url": https://github.com/onionshare/onionshare,
+            "title": Onionshare,
+            "icon_url": http://lldan5gahapx5k7iafb3s4ikijc4ni7gx5iywdflkba5y2ezyg6sjgyd.onion/assets/logo/onionshare-logo-lm.png,
+            "screenshots": [
+               http://lldan5gahapx5k7iafb3s4ikijc4ni7gx5iywdflkba5y2ezyg6sjgyd.onion/assets/features/receive-lm.png,
+               http://lldan5gahapx5k7iafb3s4ikijc4ni7gx5iywdflkba5y2ezyg6sjgyd.onion/assets/features/chat-lm.png
+            ],
+            "official_site": https://onionshare.org/,
+            "languages": [
+                "Python"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Onionshare allows one to share files, chat and even host a website anonymously over TOR.

## Project URL
https://github.com/onionshare/onionshare

## Category
Sharing Files or the Productivity category would be the best places to share them in. 

## Description
Adding OnionShare as I believe with it being all done over TOR it adds to privacy for its users. 
 
## Why it should be included to `Awesome macOS open source applications ` (optional)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x ] Only one project/change is in this pull request
- [x ] Screenshots(s) added if any
- [x ] Has a commit from less than 2 years ago
- [ x] Has a **clear** README in English
