### PR TITLE
Add far2l fork of FAR Manager

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -5837,6 +5837,22 @@
             ]
         },
         {
+            "short_description": "Linux/Mac fork of FAR Manager v2",
+            "categories": [
+                "productivity",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/elfmz/far2l",
+            "title": "far2l",
+            "icon_url": "https://raw.githubusercontent.com/elfmz/far2l/master/far2l/DE/icons/far2l.svg",
+            "screenshots": [],
+            "official_site": "",
+            "languages": [
+                "c",
+                "cpp"
+            ]
+        },
+        {
             "short_description": "Monitor your Mac's fan speed and CPU temperature from your Notification Center. ",
             "categories": [
                 "system"


### PR DESCRIPTION
## Project URL
https://github.com/elfmz/far2l

## Category
utilities, productivity

## Description
Linux/Mac fork of FAR Manager v2 (http://farmanager.com/)

Plug-ins that are currently working: NetRocks (SFTP/SCP/FTP/FTPS/SMB/NFS/WebDAV), colorer, multiarc, tmppanel, align, autowrap, drawline, editcase, SimpleIndent, Calculator, Python (optional scripting support)
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
This is a pretty good fork of a classical must-have two panels file managers from the windows world

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [ ] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
