### PR TITLE
Fixing typo in the PercentCalculator entry

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -6535,7 +6535,7 @@
             ]
         },
         {
-            "short_description": "A menu bar application that calculates parcents. ",
+            "short_description": "A menu bar application that calculates percents. ",
             "categories": [
                 "utilities"
             ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/serhii-londar/open-source-mac-os-apps/

## Category
utilities

## Description
Changed 'parcents' to 'percents' in the short_description field.


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
