### PR TITLE
Fixing typo in the Bitwarden Menu entry

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -6499,7 +6499,7 @@
             ]
         },
         {
-            "short_description": "Bitwarden Passwort Manager in your menu bar",
+            "short_description": "Bitwarden Password Manager in your menu bar",
             "categories": [
                 "utilities"
             ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/serhii-londar/open-source-mac-os-apps/

## Category
utilities

## Description
Changed 'Passwort' to 'Password' in the short_description field.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
