### PR TITLE
Added OpenRocket

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -9234,6 +9234,20 @@
             ]
         },
         {
+            "short_description": "OpenRocket is a cross-platform utility tool to model and simulate model rockets and their flight characteristics.",
+            "categories": [
+                "utilities"
+            ],
+            "repo_url": "https://github.com/openrocket/openrocket",
+            "title": "OpenRocket",
+            "icon_url": "",
+            "screenshots": [],
+            "official_site": "https://openrocket.info/",
+            "languages": [
+                "java"
+            ]
+        },
+        {
             "short_description": "Cyberduck is a libre server and cloud storage browser for Mac and Windows with support for FTP, SFTP, WebDAV, Amazon S3, OpenStack Swift, Backblaze B2, Microsoft Azure & OneDrive, Google Drive and Dropbox.",
             "categories": [
                 "sharing-files"


### PR DESCRIPTION
Added OpenRocket to the utilities section.


## Project URL
https://github.com/openrocket/openrocket and https://openrocket.info/

## Category
Utilities

## Description
I added an entry to the applications.json that adds OpenRocket under the utilities section. 
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
OpenRocket is a free, open-source alternative to some other rocketry simulation software. The program is cross-platform and super useful for simulating the characteristics of a model rocket under different situations. I hope you find this program as interesting as I do!

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
