### PR TITLE
Added UTM

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -4334,6 +4334,23 @@
             ]
         },
         {
+            "short_description": "Virtualization for other operating systems.",
+            "categories": [
+                "development"
+            ],
+            "repo_url": "https://github.com/utmapp/",
+            "title": "utmapp",
+            "icon_url": "",
+            "screenshots": [
+                "https://github.com/utmapp/UTM/raw/main/screenmac.png"
+            ],
+            "official_site": "https://mac.getutm.app/",
+            "languages": [
+                "swift",
+                "objective_c"
+            ]
+        },
+        {
             "short_description": "Control Spotify without leaving your terminal. :notes: ",
             "categories": [
                 "music"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/utmapp/UTM

## Category
Development

## Description
Added UTM
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
There are many paid OS virtualization options for Mac such as Parallels and VMware. but many developers would prefer more open-source, free options. VirtualBox has become outdated/buggy, and having used UTM for the last few months. it has proven a strong contender.


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
