### PR TITLE
BarTranslate, a handy menubar translator app.

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,7 +1,7 @@
 {
     "applications": [
         {
-          "short_description": "A handy menubar translator app using Google Translate.",
+          "short_description": "A handy menu bar translator app that supports DeepL and Google Translate.",
           "categories": [
             "menubar"
           ],

--- a/applications.json
+++ b/applications.json
@@ -9,7 +9,6 @@
           "title": "BarTranslate",
           "icon_url": "https://github.com/ThijmenDam/BarTranslate/raw/master/assets/BarTranslateIcon%402x.png",
           "screenshots": [
-            "https://thijmendam.github.io/BarTranslate/assets/images/interface-snapshot.png",
             "https://thijmendam.github.io/BarTranslate/assets/images/interface-snapshot.png"
           ],
           "official_site": "https://thijmendam.github.io/BarTranslate/",

--- a/applications.json
+++ b/applications.json
@@ -1,6 +1,23 @@
 {
     "applications": [
-           {
+        {
+          "short_description": "A handy menubar translator app using Google Translate.",
+          "categories": [
+            "menubar"
+          ],
+          "repo_url": "https://github.com/ThijmenDam/BarTranslate",
+          "title": "BarTranslate",
+          "icon_url": "https://github.com/ThijmenDam/BarTranslate/raw/master/assets/BarTranslateIcon%402x.png",
+          "screenshots": [
+            "https://thijmendam.github.io/BarTranslate/assets/images/interface-snapshot.png",
+            "https://thijmendam.github.io/BarTranslate/assets/images/interface-snapshot.png"
+          ],
+          "official_site": "https://thijmendam.github.io/BarTranslate/",
+          "languages": [
+            "typescript"
+          ]
+        },
+        {
             "short_description": "Keka is a full featured file archiver, as easy as it can be.",
             "categories": [
                 "utilities"
@@ -9493,7 +9510,7 @@
             "languages": [
                 "javascript"
             ]
-        },         
+        },
         {
             "short_description": "Modern open-source code editor for HTML, CSS and JavaScript that's built in HTML, CSS and JavaScript.",
             "categories": [
@@ -9608,7 +9625,7 @@
             "languages": [
                 "rust"
             ]
-        },    
+        },
         {
             "short_description": "Widelands is a free, open source real-time strategy game with singleplayer campaigns and a multiplayer mode. The game was inspired by Settlers II™ (© Bluebyte) but has significantly more variety and depth to it.",
             "categories": [

--- a/applications.json
+++ b/applications.json
@@ -7,7 +7,7 @@
           ],
           "repo_url": "https://github.com/ThijmenDam/BarTranslate",
           "title": "BarTranslate",
-          "icon_url": "https://github.com/ThijmenDam/BarTranslate/raw/master/assets/BarTranslateIcon%402x.png",
+          "icon_url": "https://raw.githubusercontent.com/ThijmenDam/BarTranslate/master/assets/BarTranslateIcon.png",
           "screenshots": [
             "https://thijmendam.github.io/BarTranslate/assets/images/interface-snapshot.png"
           ],


### PR DESCRIPTION
## Project URL
https://github.com/ThijmenDam/BarTranslate

## Category
Menubar

## Description
BarTranslate, a handy menubar translator app using Google Translate.
 
## Why it should be included to `Awesome macOS open source applications `
I use BarTranslate almost everyday, and thus I think someone else might find it useful too! It provides quick access to Google Translate and supports numerous keyboard shortcuts to make translating anything quick and easy,.


## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English