### PR TITLE
add BrewMate - homebrew gui

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -9606,6 +9606,18 @@
             "languages": [
                 "c"
             ]
-}
+        },
+        {
+        "short_description": "Homebrew and Open Source GUI application manager",
+        "categories": ["utilities", "productivity"],
+        "repo_url": "https://github.com/romankurnovskii/BrewMate",
+        "title": "BrewMate",
+        "icon_url": "https://a.fsdn.com/allura/p/brewmate/icon?4b8fd854030ed7eb6d9f45914590f62be6acf6e3ced47045abcd54971c81aeb0?&w=180",
+        "screenshots": [
+            "https://raw.githubusercontent.com/romankurnovskii/BrewMate/main/assets/mainwindow.gif"
+        ],
+        "official_site": "https://romankurnovskii.com/brewmate/",
+        "languages": ["typescript"]
+        }
     ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/romankurnovskii/BrewMate

## Category
Utilities, Productivity

## Description
BrewMate - Homebrew and Open Source apps manager.
Open Source apps are being fetched from: https://github.com/serhii-londar/open-source-mac-os-apps

BrewMate is a macOS GUI application that makes it easy to search for, install, and uninstall Homebrew casks. You can also see the top downloaded casks for the last month.


 
## Why it should be included to `Awesome macOS open source applications ` (optional)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
