### PR TITLE
Add Clipboard tool to applications.json

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -5405,6 +5405,25 @@
             ]
         },
         {
+            "short_description": "An easy-to-use clipboard manager with time saving features that work across all terminals.",
+            "categories": [
+                "development",
+                "productivity",
+                "terminal"
+            ],
+            "repo_url": "https://github.com/Slackadays/Clipboard",
+            "title": "Clipboard",
+            "icon_url": "https://raw.githubusercontent.com/Slackadays/Clipboard/main/documentation/website/static/cb_small.png",
+            "screenshots": [
+               "https://raw.githubusercontent.com/Slackadays/Clipboard/main/documentation/website/static/demo.png",
+               "https://raw.githubusercontent.com/Slackadays/Clipboard/main/documentation/readme-assets/ClipboardDemo.gif"
+            ],
+            "official_site": "https://GetClipboard.app",
+            "languages": [
+                "cpp"
+            ]
+        },
+        {
             "short_description": "Unofficial Trello app. ",
             "categories": [
                 "productivity"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/Slackadays/Clipboard
https://GetClipboard.app

## Categories
Development, Productivity, and Terminal.

## Description
<!--- Describe your changes in detail -->

Paraphrasing this from the readme:

Clipboard is an easy-to-use clipboard manager with tons of time saving features and gorgeous eye candy.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)

Unlike all the other cross-platform clipboard managers out there, Clipboard lives entirely in the terminal. This lends it a unique proposition for use in scripts or by those of us who get things done better in the terminal. Best of all, it's GPLv3 licensed, works really well on macOS especially, and is filled with eye candy which should please designers.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English
