### PR TITLE
Add ScreenHint to applications.json

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -9592,6 +9592,26 @@
           ]
         },
         {
+            "short_description": "A simple screenshotting utility for thinking clearly.",
+            "categories": [
+                "productivity",
+                "menubar",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/salemhilal/ScreenHint",
+            "title": "ScreenHint",
+            "icon_url": "https://raw.githubusercontent.com/salemhilal/ScreenHint/main/ScreenHint/Assets.xcassets/AppIcon.appiconset/Icon-1024.png?raw=true",
+            "screenshots": [
+                "https://github.com/salemhilal/screenhint-site/blob/main/src/static/img/features/screenhint-in-action.png?raw=true",
+                "https://github.com/salemhilal/screenhint-site/blob/main/src/static/img/features/code-hints.png?raw=true",
+                "https://github.com/salemhilal/screenhint-site/blob/main/src/static/img/features/bike-ride-hints.png?raw=true",
+            ],
+            "official_site": "https://screenhint.com",
+            "languages": [
+                "swift"
+            ]
+        },
+        {
             "short_description": "Instant messaging application that can connect to XMPP (Jabber), IRC and more.",
             "categories": [
                 "chat"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://screenhint.com

## Category
Productivity (or maybe Menubar)

## Description
I added ScreenHint to the list of apps in `applications.json`.

ScreenHint is a tool for thinking visually. It allows you to create temporary floating screenshots which you can reference as you work, almost like having photographic memory. It's helpful for brainstorming, collaging, or keeping a reference close at hand as you work.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
I feel like ScreenHint has finally reached a decent level of maturity and is ready to be seen by more people. Plus, I've received a lot of help from people in the open-source macOS app world, and I feel like sharing my code in kind is the right idea.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English
