### PR TITLE
Add VSCodium to editors list

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,8 @@ You can see in which language an app is written. Currently there are following l
 
 ### Editors
 - [AuroraEditor](https://github.com/AuroraEditor/AuroraEditor) - Lightweight Code Editor (IDE) for macOS.  ![swift_icon] 
-- [CodeEdit](https://github.com/CodeEditApp/CodeEdit) - CodeEdit App for macOS – Elevate your code editing experience. Open source, free forever. ![swift_icon] 
+- [CodeEdit](https://github.com/CodeEditApp/CodeEdit) - CodeEdit App for macOS – Elevate your code editing experience. Open source, free forever. ![swift_icon]
+- [VSCodium](https://vscodium.com/) - Open source software binaries of Visual Studio Code, without telemetry. ![typescript_icon]
 
 #### CSV
 - [TableTool](https://github.com/jakob/TableTool) - simple CSV editor for the macOS.  ![objective_c_icon] 

--- a/applications.json
+++ b/applications.json
@@ -9606,6 +9606,23 @@
             "languages": [
                 "c"
             ]
-}
+        },
+        {
+            "short_description": "Open source binaries of Visual Studio Code, without telemetry or proprietary software.",
+            "categories": [
+                "editors"
+            ],
+            "repo_url": "https://github.com/VSCodium/vscodium",
+            "title": "VSCodium",
+            "icon_url": "https://vscodium.com/img/codium_cnl.svg",
+            "screenshots": [
+               "https://vscodium.com/img/vscodium.png"
+            ],
+            "official_site": "https://vscodium.com",
+            "languages": [
+                "typescript",
+                "javascript"
+            ]
+        }
     ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://vscodium.com/

## Category
Editors

## Description
Edited applications.json to include an entry for VSCodium. An accidental change to README.md was reverted.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
VSCodium is a widely used alternative to the proprietary VSCode.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [ x] Only one project/change is in this pull request
- [ x] Screenshots(s) added if any
- [x ] Has a commit from less than 2 years ago
- [ x] Has a **clear** README in English
