### PR TITLE
Add VSCodium entry to applications.json

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -9606,6 +9606,23 @@
             "languages": [
                 "c"
             ]
-}
+        },
+        {
+            "short_description": "Open source binaries of Visual Studio Code, without telemetry or proprietary software.",
+            "categories": [
+                "editors"
+            ],
+            "repo_url": "https://github.com/VSCodium/vscodium",
+            "title": "VSCodium",
+            "icon_url": "https://vscodium.com/img/codium_cnl.svg",
+            "screenshots": [
+               "https://vscodium.com/img/vscodium.png"
+            ],
+            "official_site": "https://vscodium.com/",
+            "languages": [
+                "typescript",
+                "javascript"
+            ]
+        }
     ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
[https://vscodium.com/](https://vscodium.com/)

## Category
Editors

## Description
Added VSCodium entry to applications.json
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
VSCodium is an open source, widely used alternative to VSCode avaliable for MacOS.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
