### PR TITLE
Added gPodder

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -9606,6 +9606,22 @@
             "languages": [
                 "c"
             ]
-}
+		},
+		{
+            "short_description": "gPodder is a simple, open source podcast client.",
+            "categories": [
+                "podcast"
+            ],
+            "repo_url": "https://github.com/gpodder/gpodder",
+            "title": "gPodder",
+            "icon_url": "",
+            "screenshots": [
+				"https://gpodder.github.io/assets/screenshot-2022-03-24-crop.png"
+            ],
+            "official_site": "https://gpodder.github.io/",
+            "languages": [
+                "python"
+            ]
+        }
     ]
 }

--- a/applications.json
+++ b/applications.json
@@ -9614,7 +9614,7 @@
             ],
             "repo_url": "https://github.com/gpodder/gpodder",
             "title": "gPodder",
-            "icon_url": "",
+            "icon_url": "https://raw.githubusercontent.com/gpodder/gpodder/master/share/icons/hicolor/64x64/apps/gpodder.png",
             "screenshots": [
 				"https://gpodder.github.io/assets/screenshot-2022-03-24-crop.png"
             ],


### PR DESCRIPTION
Added the opensource podcast aggregator gPodder.

## Project URL
[https://github.com/gpodder/gpodder](https://github.com/gpodder/gpodder)

## Category
Podcast

## Description
Added a new entry to the applications.json by adding the information for gPodder
 
## Why it should be included to `Awesome macOS open source applications ` (optional)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
