### PR TITLE
Added defguard client

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -6835,6 +6835,20 @@
             ]
         },
         {
+            "short_description": "WireGuard VPN client with real 2FA/MFA support",
+            "categories": [
+                "vpn--proxy"
+            ],
+            "repo_url": "https://github.com/defguard/client",
+            "title": "Defguard",
+            "icon_url": "",
+            "screenshots": ['https://camo.githubusercontent.com/25672075639b7c8be8a9341fcfe51e26620d9741ee5f26bb7272f9eb86cdcc0a/68747470733a2f2f64656667756172642e6e65742f696d616765732f70726f647563742f636c69656e742f6d61696e2d73637265656e2e706e67'],
+            "official_site": "https://defguard.net/client",
+            "languages": [
+                "Rust", "React"
+            ]
+        },
+        {
             "short_description": "Next Generation of ShadowsocksX. ",
             "categories": [
                 "vpn--proxy"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL

https://github.com/DefGuard/client?tab=readme-ov-file

## Category

VPN & Proxy

## Description

I've added defguard open source desktop WireGuard VPN client
 
## Why it should be included to `Awesome macOS open source applications ` (optional)

Because it's the best WireGuard desktop client there is!

## Checklist

- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English
