### PR TITLE
add wave terminal to the list

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -6265,6 +6265,26 @@
             ]
         },
         {
+            "short_description": "Wave is an open-source, AI-native terminal built for seamless developer workflows with inline rendering, a modern UI, and persistent sessions.",
+            "categories": [
+                "terminal"
+            ],
+            "repo_url": "https://github.com/wavetermdev/waveterm",
+            "title": "Wave Terminal",
+            "icon_url": "",
+            "screenshots": [
+                "https://mintlify.s3-us-west-1.amazonaws.com/commandline/images/screenshot.png",
+                "https://mintlify.s3-us-west-1.amazonaws.com/commandline/images/codeedit.gif",
+                "https://mintlify.s3-us-west-1.amazonaws.com/commandline/images/waveai.gif",
+                "https://mintlify.s3-us-west-1.amazonaws.com/commandline/images/fileViewers/pdfview.gif",
+                "https://mintlify.s3-us-west-1.amazonaws.com/commandline/images/history_cmdh.gif"
+            ],
+            "official_site": "https://waveterm.dev",
+            "languages": [
+                "go"
+            ]
+        },
+        {
             "short_description": "One-click screenshots, video recordings, app installation for iOS and Android ",
             "categories": [
                 "utilities"


### PR DESCRIPTION
## Project URL
https://github.com/wavetermdev/waveterm

## Category
Terminal

## Description
Added Wave Terminal to the "Terminal" category
 
## Why it should be included to `Awesome macOS open source applications ` (optional)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
