### PR TITLE
Add SwitchShuttle

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -4881,6 +4881,22 @@
             ]
         },
         {
+            "short_description": "Simple commands shortcut menu for macOS. ",
+            "categories": [
+                "other"
+            ],
+            "repo_url": "https://github.com/s00d/switchshuttle",
+            "title": "SwitchShuttle",
+            "icon_url": "https://github.com/s00d/switchshuttle/blob/main/icons/128x128.png?raw=true",
+            "screenshots": [
+                "https://github.com/s00d/switchshuttle/raw/main/icons/intro.gif?raw=true"
+            ],
+            "official_site": "",
+            "languages": [
+                "rust"
+            ]
+        },
+        {
             "short_description": "Convenient logging during development & release in Swift. ",
             "categories": [
                 "other"


### PR DESCRIPTION
Added the opensource command manager SwitchShuttle.

## Project URL
https://github.com/s00d/switchshuttle

## Category
Other

## Description
SwitchShuttle is a cross-platform system tray application that allows users to run predefined commands in various terminal applications.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)


## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
