### PR TITLE
Add Applite

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -9710,6 +9710,23 @@
             "languages": [
                 "python"
             ]
+        },
+        {
+            "short_description": "User-friendly GUI app for Homebrew Casks. Install, update, and uninstall apps with a single click.",
+            "categories": [
+                "downloader"
+            ],
+            "repo_url": "https://github.com/milanvarady/Applite",
+            "title": "Applite",
+            "icon_url": "https://aerolite.dev/img/applite/AppliteIcon512.png",
+            "screenshots": [
+               "https://aerolite.dev/img/applite/discover-page.png",
+               "https://aerolite.dev/img/applite/productivity.png"
+            ],
+            "official_site": "https://aerolite.dev/applite",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Add Applite app

## Project URL
[Applite repository](https://github.com/milanvarady/Applite)

## Category
downloader

## Description

Add Applite app. Applite is an open source GUI client for Homebrew that aims to bring the convenience of Homebrew casks to the non-technical user.

Key features of Applite:
- Install, update, and uninstall apps with a single click
- Clean and simple UI designed for non-technical users
- Free and open source
- Works with existing brew installation
- Supports system proxy (HTTP, HTTPS, and SOCKS5)
- Handpicked gallery of awesome apps
 
## Why it should be included to `Awesome macOS open source applications ` (optional)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
