### PR TITLE
Wireshark was labelled incorrectly as Nmap

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -6785,7 +6785,7 @@
                 "utilities"
             ],
             "repo_url": "https://github.com/wireshark/wireshark",
-            "title": "Nmap",
+            "title": "Wireshark",
             "icon_url": "",
             "screenshots": [],
             "official_site": "https://www.wireshark.org",


### PR DESCRIPTION
Wireshark was labelled incorrectly as Nmap

<!--- Provide a general summary of your changes in the Title above -->

## Project URL
<!--- The project URL -->

## Category
<!--- Category in Awesome macOS open source applications where the project will be added -->

## Description
<!--- Describe your changes in detail -->
 
## Why it should be included to `Awesome macOS open source applications ` (optional)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
