### PR TITLE
Add app-menu

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -3958,6 +3958,23 @@
             ]
         },
         {
+            "short_description": "The missing Applications Menu for macOS.",
+            "categories": [
+                "menubar"
+            ],
+            "repo_url": "https://github.com/barseghyanartur/app-menu",
+            "title": "app-menu",
+            "icon_url": "https://github.com/barseghyanartur/app-menu/blob/main/ApplicationMenu/Assets.xcassets/AppIcon.appiconset/icon_32x32.png",
+            "screenshots": [
+		"https://github.com/barseghyanartur/app-menu/blob/main/Docs/app_menu_screenshot.jpg",
+		"https://github.com/barseghyanartur/app-menu/blob/main/Docs/app_menu_configuration_dir_access.jpg"
+	    ],
+            "official_site": "",
+            "languages": [
+                "swift"
+            ]
+        },
+        {
             "short_description": "Put the output from any script or program into your macOS Menu Bar. ",
             "categories": [
                 "menubar"


### PR DESCRIPTION
https://github.com/barseghyanartur/app-menu

Added app-menu application.

## Project URL
[app-menu](https://github.com/barseghyanartur/app-menu)

## Category
menubar

## Description
The missing Applications Menu for macOS.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
It's helpful.

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
