### PR TITLE
Add mxMarkEdit

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,13 @@
 <!--- Provide a general summary of your changes in the Title above -->
 
 ## Project URL
-<!--- The project URL -->
+https://github.com/maxnd/mxMarkEdit
 
 ## Category
-<!--- Category in Awesome macOS open source applications where the project will be added -->
+markdown, text, editors
 
 ## Description
-<!--- Describe your changes in detail -->
+mxMarkEdit is a free software for Mac for writing texts and todo items in Markdown format and easily exporting them to other formats with Pandoc. In each document, it’s available an Excel-like grid useful to manage various sets of data. Some Markdown markers are hidden, as the text that follows them or is contained within them is properly formatted. At the left of the text, there’s a list of the titles and todo items. By clicking on an item in this list, the cursor moves to the corresponding title or todo item. While moving the cursor in the text, the corresponding title or todo item is highlighted. The app has many functionalities and shortcuts to manage easily a document.
  
 ## Why it should be included to `Awesome macOS open source applications ` (optional)
 
@@ -15,8 +15,8 @@
 ## Checklist
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-- [ ] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
-- [ ] Only one project/change is in this pull request
-- [ ] Screenshots(s) added if any
-- [ ] Has a commit from less than 2 years ago
-- [ ] Has a **clear** README in English
+- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
+- [X] Only one project/change is in this pull request
+- [X] Screenshots(s) added if any
+- [X] Has a commit from less than 2 years ago
+- [X] Has a **clear** README in English

--- a/applications.json
+++ b/applications.json
@@ -1,6 +1,26 @@
 {
     "applications": [
         {
+          "short_description": "Visual editor of Markdown document, tasks and tables.",
+          "categories": [
+                "markdown",
+                "editors",
+                "text"          ],
+          "repo_url": "https://github.com/maxnd/mxMarkEdit",
+          "title": "mxMarkEdit",
+          "icon_url": "https://github.com/maxnd/mxMarkEdit/blob/main/icon128.png",
+          "screenshots": [
+            "https://github.com/maxnd/mxMarkEdit/blob/main/screenshots/screenshot1.png",
+            "https://github.com/maxnd/mxMarkEdit/blob/main/screenshots/screenshot2.png",
+            "https://github.com/maxnd/mxMarkEdit/blob/main/screenshots/screenshot3.png",
+            "https://github.com/maxnd/mxMarkEdit/blob/main/screenshots/screenshot4.png"
+          ],
+          "official_site": "https://github.com/maxnd/mxMarkEdit",
+          "languages": [
+            "free-pascal"
+          ]
+        },
+        {
           "short_description": "A handy menu bar translator app that supports DeepL and Google Translate.",
           "categories": [
             "menubar"

--- a/applications.json
+++ b/applications.json
@@ -1,7 +1,7 @@
 {
     "applications": [
         {
-          "short_description": "Visual editor of Markdown document, tasks and tables.",
+          "short_description": "A visual editor of Markdown document, tasks and tables.",
           "categories": [
                 "markdown",
                 "editors",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/maxnd/mxMarkEdit

## Category
markdown, text, editors

## Description
mxMarkEdit is a free software for Mac for writing texts and todo items in Markdown format and easily exporting them to other formats with Pandoc. In each document, it’s available an Excel-like grid useful to manage various sets of data. Some Markdown markers are hidden, as the text that follows them or is contained within them is properly formatted. At the left of the text, there’s a list of the titles and todo items. By clicking on an item in this list, the cursor moves to the corresponding title or todo item. While moving the cursor in the text, the corresponding title or todo item is highlighted. The app has many functionalities and shortcuts to manage easily a document.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English
