### PR TITLE
Add TimeScribe

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -9727,6 +9727,29 @@
             "languages": [
                 "swift"
             ]
+        },
+	{
+            "short_description": "Simple and free working time recording.",
+            "categories": [
+                "menubar",
+		"productivity"
+            ],
+            "repo_url": "https://github.com/WINBIGFOX/timescribe",
+            "title": "TimeScribe",
+            "icon_url": "https://raw.githubusercontent.com/WINBIGFOX/timescribe/refs/heads/main/public/icon.png",
+            "screenshots": [
+		"https://raw.githubusercontent.com/WINBIGFOX/timescribe/refs/heads/main/.github/images/menubar_light.png",
+                "https://raw.githubusercontent.com/WINBIGFOX/timescribe/refs/heads/main/.github/images/dayview_en_light.webp",
+                "https://raw.githubusercontent.com/WINBIGFOX/timescribe/refs/heads/main/.github/images/app_activity_en_light.webp",
+		"https://raw.githubusercontent.com/WINBIGFOX/timescribe/refs/heads/main/.github/images/absences_en_light.webp",
+		"https://raw.githubusercontent.com/WINBIGFOX/timescribe/refs/heads/main/.github/images/start_break_en_light.webp"
+            ],
+            "official_site": "https://timescribe.app",
+            "languages": [
+                "css",
+		"javascript",
+		"typescript",
+            ]
         }
     ]
 }


### PR DESCRIPTION
Add TimeScribe - Open-Source Time Tracking for Mac Users

## Project URL
[TimeScribe](https://timescribe.app/)

## Category
Productivity, Menubar

## Description
TimeScribe is an open-source time-tracking application designed specifically for Mac users. It offers a user-friendly interface to track work hours, manage breaks, and categorize app activities. Key features include easy time tracking, automatic break management, app activity monitoring, absence tracking, and auto start/break functionality based on computer usage or specified times. The project aims to provide a free, community-driven alternative to paid time-tracking solutions.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
TimeScribe fills a gap in the open-source ecosystem by providing a robust, user-friendly time-tracking solution tailored for Mac users. Its features are on par with paid alternatives, making it a valuable addition to the list of awesome macOS open-source applications. Additionally, its open-source nature encourages community contributions and continuous improvement.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
