### PR TITLE
Add Input Source Pro

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -9750,6 +9750,20 @@
 		"javascript",
 		"typescript",
             ]
-        }
+        },
+	{
+            "short_description": "Input Source Pro is macOS utility designed for multilingual users who frequently switch input sources.",
+            "categories": [
+                "keyboard", "utilities", "ios--macos"
+            ],
+            "repo_url": "https://github.com/runjuu/InputSourcePro/",
+            "title": "Input Source Pro",
+            "icon_url": "https://camo.githubusercontent.com/858c5c213d9937d100e0837f6f37f67652457acada5fd1f17253060da568e5e1/68747470733a2f2f696e707574736f757263652e70726f2f696d672f6170702d69636f6e2e706e67",
+            "screenshots": [],
+            "official_site": "https://inputsource.pro",
+            "languages": [
+                "swift"
+            ]
+         }
     ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL : [Input Source Pro](https://github.com/runjuu/InputSourcePro/)

## Category
Keyboard, macOS

## Description
<!--- Describe your changes in detail -->
Input Source Pro is a free and open-source macOS utility designed for multilingual users who frequently switch input sources. It automates input source switching based on the active application or even the specific website you're browsing significantly boosting your productivity and typing experience.
 

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [ ] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
