### PR TITLE
Add Gridfy app

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -9754,7 +9754,6 @@
         {
             "short_description": "Quickly calculate column widths and get correct results for your grid.",
             "categories": [
-                "productivity",
                 "utilities",
                 "development"
 

--- a/applications.json
+++ b/applications.json
@@ -9728,27 +9728,48 @@
                 "swift"
             ]
         },
-	{
+        {
             "short_description": "Simple and free working time recording.",
             "categories": [
                 "menubar",
-		"productivity"
+		        "productivity"
             ],
             "repo_url": "https://github.com/WINBIGFOX/timescribe",
             "title": "TimeScribe",
             "icon_url": "https://raw.githubusercontent.com/WINBIGFOX/timescribe/refs/heads/main/public/icon.png",
             "screenshots": [
-		"https://raw.githubusercontent.com/WINBIGFOX/timescribe/refs/heads/main/.github/images/menubar_light.png",
+		        "https://raw.githubusercontent.com/WINBIGFOX/timescribe/refs/heads/main/.github/images/menubar_light.png",
                 "https://raw.githubusercontent.com/WINBIGFOX/timescribe/refs/heads/main/.github/images/dayview_en_light.webp",
                 "https://raw.githubusercontent.com/WINBIGFOX/timescribe/refs/heads/main/.github/images/app_activity_en_light.webp",
-		"https://raw.githubusercontent.com/WINBIGFOX/timescribe/refs/heads/main/.github/images/absences_en_light.webp",
-		"https://raw.githubusercontent.com/WINBIGFOX/timescribe/refs/heads/main/.github/images/start_break_en_light.webp"
+		        "https://raw.githubusercontent.com/WINBIGFOX/timescribe/refs/heads/main/.github/images/absences_en_light.webp",
+		        "https://raw.githubusercontent.com/WINBIGFOX/timescribe/refs/heads/main/.github/images/start_break_en_light.webp"
             ],
             "official_site": "https://timescribe.app",
             "languages": [
                 "css",
-		"javascript",
-		"typescript",
+		        "javascript",
+		        "typescript"
+            ]
+        },
+        {
+            "short_description": "Quickly calculate column widths and get correct results for your grid.",
+            "categories": [
+                "productivity",
+                "utilities",
+                "development"
+
+            ],
+            "repo_url": "https://github.com/Slllava/gridfy",
+            "title": "Gridfy",
+            "icon_url": "https://raw.githubusercontent.com/Slllava/gridfy/refs/heads/main/Gridfy/Assets.xcassets/Icons/AppIcon.appiconset/Icon-512.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/Slllava/gridfy/refs/heads/main/media/pr-01.png",
+                "https://raw.githubusercontent.com/Slllava/gridfy/refs/heads/main/media/pr-02.png",
+                "https://raw.githubusercontent.com/Slllava/gridfy/refs/heads/main/media/pr-03.png"
+            ],
+            "official_site": "https://gridfy.astroon.pro/",
+            "languages": [
+                "swift"
             ]
         }
     ]


### PR DESCRIPTION
Grid Calculator for Mac OS

## Project URL
https://github.com/Slllava/gridfy

## Category
Utilities, Development

## Description
Build the perfect layout for your site or application.
Calculate column widths quickly and get correct results.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
It’s the only grid calculator for Mac.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
