### PR TITLE
Add Dockit

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -9750,6 +9750,23 @@
 		"javascript",
 		"typescript",
             ]
+        },
+        {
+            "short_description": "An application that can dock any window to the edge of the screen.",
+            "categories": [
+                "window-management",
+                "productivity"
+            ],
+            "repo_url": "https://github.com/xicheng148/Dockit",
+            "title": "Dockit",
+            "icon_url": "https://github.com/XiCheng148/Dockit/blob/main/Resources/dmg-icon.svg?raw=true",
+            "screenshots": [
+                "https://github.com/XiCheng148/Dockit/blob/main/Resources/preview.gif?raw=true"
+            ],
+            "official_site": "[official site](https://dockit-docs.pages.dev/?s=open-sourse-mac-os-apps)",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
An application that can dock any window to the edge of the screen.

## Project URL
https://github.com/xicheng148/dockit

## Category
- window-management
- productivity

## Description
Dockit is a macOS window management tool focused on quickly docking windows to the edge of the screen and quickly previewing windows.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
- Quick Docking: Allows users to easily dock windows to the sides of the screen.
- Smart Display: Features auto-expand on hover and auto-collapse on leaving the hover area, keeping the desktop tidy.
- Keyboard Shortcut Support: Offers customizable keyboard shortcuts for window management actions.
- Flexible Configuration: Users can adjust settings like exposed width and trigger areas.
- Notifications: Provides aesthetically pleasing notifications.
These features can significantly improve productivity and workflow for users who manage multiple applications and windows


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
