### PR TITLE
Add Window Glue

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -9750,6 +9750,22 @@
 		"javascript",
 		"typescript",
             ]
+        },
+	{
+            "short_description": "A simple macOS menu bar utility that lets you glue two windows together so that they behave (mostly) as one.",
+            "categories": [
+                "window-management"
+            ],
+            "repo_url": "https://github.com/Conxt/WindowGlue",
+            "title": "Window Glue",
+            "icon_url": "https://github.com/Conxt/WindowGlue/raw/main/Assets/Icon-MacOS-256x256.png",
+            "screenshots": [
+		"https://github.com/Conxt/WindowGlue/raw/main/Assets/Screen.gif"
+            ],
+            "official_site": "",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/Conxt/WindowGlue

## Category
Window Management

## Description
Window Glue is a simple macOS menu bar utility that lets the user glue two windows together so that they behave as one window (move together, resize together, the inner border of a window pair behaves as a split view).
 
## Why it should be included to `Awesome macOS open source applications ` (optional)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
