### PR TITLE
Add MacPacker

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -9750,6 +9750,22 @@
 		"javascript",
 		"typescript",
             ]
+        },
+	{
+            "short_description": "Archive manager for macOS. Preview (nested) archives without extracting them. Extract single files.",
+            "categories": [
+                "utilities"
+            ],
+            "repo_url": "https://github.com/sarensw/MacPacker/",
+            "title": "MacPacker",
+            "icon_url": "https://macpacker.app/icon_512x512@2x.png",
+            "screenshots": [
+                "https://macpacker.app/main.png"
+            ],
+            "official_site": "https://macpacker.app/ ",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Add MacPacker - Open-Source Archive Manager for Mac Users

## Project URL
[MacPacker](https://macpacker.app/)

## Category
Utilities

## Description
MacPacker is an open-source Archive Manager for macOS. It supports previewing archives and nested archives including extraction of single (multiple) files.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
There's many alternatives out there to extract archives. But they usually tend to extract the full archive. This is unnecessary if you want to extract just a single file. A previewer that supports previewing nested archives doesn't exist just yet. And even the ones that allow previews are not open-sources. MacPacker aims to be the 7-zip of Windows for macOS, built by a community.

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English