### PR TITLE
Add new app 'Bye-AppQuit' to applications.json

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -15,7 +15,26 @@
           "languages": [
             "typescript"
           ]
-        },
+        },   
+		{
+		  "short_description": "A minimal native macOS app to quickly view and Bulk kill running processes.",
+		  "categories": [
+		    "menubar",
+		    "utilities",
+		    "productivity"
+		  ],
+		  "repo_url": "https://github.com/designsbymuzeer/Bye-Mac-App",
+		  "title": "Bye-AppQuit",
+		  "icon_url": "https://github.com/user-attachments/assets/33bfcf78-0bd0-42b1-999b-a5b09b729526",
+		  "screenshots": [
+		    "https://github.com/user-attachments/assets/63dade24-d967-4946-89e5-f8ae44097b31"
+			
+		  ],
+		  "official_site": "https://github.com/designsbymuzeer/Bye-Mac-App",
+		  "languages": [
+		    "swift"
+		  ]
+		},
         {
             "short_description": "Keka is a full featured file archiver, as easy as it can be.",
             "categories": [


### PR DESCRIPTION
A minimal native macOS app to quickly view and bulk kill running processes.

## Project URL
https://github.com/designsbymuzeer/Bye-Mac-App

## Category
Utilities, Menubar, Productivity

## Description
Bye is a native Swift macOS app that lives in the menu bar. It allows users to view a list of running applications and force quit them instantly. It's designed to be lightweight, fast, and privacy-focused.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
It is a high-quality, completely free, and open-source native alternative to heavy activity monitors. It fits the "Utilities" and "Menubar" categories perfectly and is actively maintained.


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
