### PR TITLE
Add MiddleDrag - middle-click trackpad gestures for macOS

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,6 +1,22 @@
 {
     "applications": [
         {
+            "short_description": "Three-finger trackpad gestures for middle-click and middle-drag.",
+            "categories": [
+                "utilities"
+            ],
+            "repo_url": "https://github.com/NullPointerDepressiveDisorder/MiddleDrag",
+            "title": "MiddleDrag",
+            "icon_url": "https://raw.githubusercontent.com/NullPointerDepressiveDisorder/MiddleDrag/main/Assets.xcassets/AppIcon.appiconset/Icon-256.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/NullPointerDepressiveDisorder/MiddleDrag/main/Screenshots/MiddleDrag-Demo.gif"
+            ],
+            "official_site": "",
+            "languages": [
+                "swift"
+            ]
+        },
+        {
           "short_description": "A handy menu bar translator app that supports DeepL and Google Translate.",
           "categories": [
             "menubar"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
<!--- The project URL -->
https://github.com/NullPointerDepressiveDisorder/MiddleDrag

## Category
<!--- Category in Awesome macOS open source applications where the project will be added -->
Utilities

## Description
<!--- Describe your changes in detail -->
MiddleDrag is a macOS menu bar app that enables middle-click and middle-drag functionality using three-finger trackpad gestures. Written in Swift.
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
Solves a long-standing pain point for CAD users (Fusion 360, Blender, Onshape) on MacBooks who need middle-mouse navigation without carrying an external mouse. It's actively maintained, has a clean native UI, and installs via Homebrew.


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
