### PR TITLE
Add ClipFlow - Clipboard History Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -10169,6 +10169,19 @@ You can see in which language an app is written. Currently there are following l
   </p>
   </details>
 
+  - [ClipFlow](https://github.com/praneeth552/clipflow) - Clipboard history manager for macOS with terminal-style navigation, image previews, and cursor-following popup.
+
+  <details>
+  <summary>More</summary>
+  <p>
+
+  **Languages:** <img src='./icons/swift-16.png' alt='Swift icon' title='Swift' height='16'/> 
+
+  **Links:** <a href='https://github.com/praneeth552/clipflow/releases/latest'><img src='https://img.shields.io/github/v/release/praneeth552/clipflow?display_name=tag&sort=semver' alt='Latest Release'/></a> &nbsp; <a href='https://github.com/praneeth552/clipflow'><img src='https://img.shields.io/github/stars/praneeth552/clipflow?style=social' alt='GitHub stars'/></a> &nbsp; <img src='https://img.shields.io/github/license/praneeth552/clipflow' alt='License'/>
+
+  </p>
+  </details>
+
 - [Clear Clipboard Text Format](https://github.com/LumingYin/ClipboardClear) - Easily clear the format of your clipboard text with Clear Clipboard Text Format.
 
   <details>


### PR DESCRIPTION
## ClipFlow

Added ClipFlow to Utilities section.

**Description:** Clipboard history manager for macOS (like Windows Win+V)

**Features:**
- Cmd+Shift+V to access history
- Terminal-style ↑↓ navigation
- Image preview support
- Native Swift app

**Link:** https://github.com/praneeth552/clipflow