### PR TITLE
Add Open mtp application

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -6053,6 +6053,24 @@
                 "cpp"
             ]
         },
+		{
+            "short_description": "Free Advanced Android File Transfer Application for macOS",
+            "categories": [
+                "Android",
+                "File Transfare"
+            ],
+            "repo_url": "https://github.com/ganeshrvel/openmtp",
+            "title": "Open mtp",
+            "icon_url": "https://github.com/ganeshrvel/openmtp/blob/master/app/app.icns",
+            "screenshots": [
+               "https://raw.githubusercontent.com/ganeshrvel/openmtp/master/blobs/images/file-explorer-bluebg.jpg",
+               "https://raw.githubusercontent.com/ganeshrvel/openmtp/master/blobs/images/file-transfer-bluebg.jpg"
+            ],
+            "official_site": "https://openmtp.ganeshrvel.com/",
+            "languages": [
+                "English"
+            ]
+        }
         {
             "short_description": "Make your battery information a bit more interesting. ",
             "categories": [


### PR DESCRIPTION
## Project URL
https://github.com/ganeshrvel/openmtp

## Category
File Transfer

## Description
Advanced Android File Transfer Application for macOS.
 
## Why it should be included to `Awesome macOS open source applications `
the only Free open source working file transfer app for android devices ( tested on 2 Samsung devices , with USB A , C cables )  

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
