### PR TITLE
Add Screenpipe to Productivity section

### DIFF
--- a/README.md
+++ b/README.md
@@ -8193,6 +8193,19 @@ You can see in which language an app is written. Currently there are following l
   </p>
   </details>
 
+- [Screenpipe](https://github.com/mediar-ai/screenpipe) - 24/7 local screen and mic recording with AI-powered search. Recall anything you've seen, said, or heard with natural language queries.
+
+  <details>
+  <summary>More</summary>
+  <p>
+
+  **Languages:** <img src='./icons/rust-16.png' alt='Rust icon' title='Rust' height='16'/> <img src='./icons/typescript-16.png' alt='TypeScript icon' title='TypeScript' height='16'/>
+
+  **Links:** <a href='https://github.com/mediar-ai/screenpipe/releases/latest'><img src='https://img.shields.io/github/v/release/mediar-ai/screenpipe?display_name=tag&sort=semver' alt='Latest Release'/></a> &nbsp; <a href='https://github.com/mediar-ai/screenpipe'><img src='https://img.shields.io/github/stars/mediar-ai/screenpipe?style=social' alt='GitHub stars'/></a> &nbsp; <img src='https://img.shields.io/github/license/mediar-ai/screenpipe' alt='License'/>
+
+  </p>
+  </details>
+
 - [Sessions](https://github.com/AlexPerathoner/Sessions) - Safari extension to save your working sessions
 
   <details>


### PR DESCRIPTION
## Summary

This PR adds [Screenpipe](https://github.com/mediar-ai/screenpipe) to the Productivity section.

**Screenpipe** is an open-source macOS (and cross-platform) app that provides:

- 🖥️ **24/7 local screen recording** - Continuously captures your screen activity
- 🎤 **Audio/mic recording** - Records what you say and hear
- 🔍 **AI-powered search** - Find anything using natural language queries
- 🔒 **Privacy-first** - All data stays local on your machine
- 🤖 **Ollama integration** - Use local LLMs for AI features

It's like having a searchable memory of everything you've seen and heard on your computer.

## Stats

- ⭐ 15k+ GitHub stars
- 📜 MIT License
- 🏗️ Built with Rust (backend) and TypeScript (frontend)
- 🖥️ Uses Tauri for the native macOS app

## Checklist

- [x] Open source (MIT license)
- [x] macOS app (also cross-platform)
- [x] Follows the repository's entry format
- [x] Alphabetically sorted in Productivity section