### PR TITLE
Add rustcast

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,5 +1,23 @@
 {
     "applications": [
+		{
+            "short_description": "Blazingly fast, customisable multi tool, application launcher",
+            "categories": [
+                "productivity",
+                "utilities",
+				"menubar"
+            ],
+            "repo_url": "https://github.com/unsecretised/rustcast",
+            "title": "RustCast",
+            "icon_url": "https://rustcast.umangsurana.com/icon.png",
+            "screenshots": [
+               "https://rustcast.umangsurana.com/rustcast-v0-5-0.png"
+            ],
+            "official_site": "https://rustcast.umangsurana.com",
+            "languages": [
+                "rust"
+            ]
+        },
         {
             "short_description": "Three-finger trackpad gestures for middle-click and middle-drag.",
             "categories": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/unsecretised/rustcast

## Category
menubar, utilities, productivity

## Description
Blazingly fast, customisable multi tool, application launcher
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
Because I feel like people shouldn't have to pay for a multi purpose spotlight. Especially since many people have been complaining that the apps don't appear even when they are an exact match. 

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
