### PR TITLE
Add AeroSpace and Loop window managers

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -7421,6 +7421,20 @@
             ]
         },
         {
+            "short_description": "AeroSpace is an i3-like tiling window manager for macOS.",
+            "categories": [
+                "window-management"
+            ],
+            "repo_url": "https://github.com/nikitabobko/AeroSpace",
+            "title": "AeroSpace",
+            "icon_url": "",
+            "screenshots": [],
+            "official_site": "https://nikitabobko.github.io/AeroSpace/",
+            "languages": [
+                "swift"
+            ]
+        },
+        {
             "short_description": "Automatic tiling window manager for macOS. ",
             "categories": [
                 "window-management"
@@ -7485,6 +7499,20 @@
             "languages": [
                 "lua",
                 "objective_c"
+            ]
+        },
+        {
+            "short_description": "Window management made elegant. A macOS app for managing your windows with ease.",
+            "categories": [
+                "window-management"
+            ],
+            "repo_url": "https://github.com/MrKai77/Loop",
+            "title": "Loop",
+            "icon_url": "",
+            "screenshots": [],
+            "official_site": "https://mrkai77.github.io/Loop/",
+            "languages": [
+                "swift"
             ]
         },
         {


### PR DESCRIPTION
## Summary
Adds two popular window management applications to the list.

## Applications Added

### 1. AeroSpace
- **Repository:** https://github.com/nikitabobko/AeroSpace
- **Description:** i3-like tiling window manager for macOS
- **Stars:** 12k+
- **Language:** Swift
- **Website:** https://nikitabobko.github.io/AeroSpace/

### 2. Loop
- **Repository:** https://github.com/MrKai77/Loop
- **Description:** Window management made elegant
- **Language:** Swift  
- **Website:** https://mrkai77.github.io/Loop/

Both are actively maintained, open source, and have significant community adoption.