### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
   generate-readme:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - run: swift ./.github/main.swift
       - run: git config user.name "serhii-londar"
       - run: git config user.email "serhii.londar@gmail.com"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,5 +10,5 @@ jobs:
       - run: gem install awesome_bot
       - run: gem install bundler
       - run: gem install danger
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - run: awesome_bot applications.json -w https://matrix.org,https://camo.githubusercontent.com,http://joshparnham.com,https://pock.pigigaldi.com,https://docs.microsoft.com/powershell/scripting/install/installing-powershell-core-on-macos?view=powershell-6,https://adequate.systems/ --allow 429


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `actions/checkout` from `v3` to `v6` in `.github/workflows/pr.yml`
- Updated `actions/checkout` from `v3` to `v6` in `.github/workflows/main.yml`
