### PR TITLE
Add Stik to Notes category

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -9837,6 +9837,21 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "short_description": "Instant thought capture for macOS. Global hotkey summons a post-it note, type and close. Notes stored as plain markdown files.",
+            "categories": [
+                "notes"
+            ],
+            "repo_url": "https://github.com/0xMassi/stik_app",
+            "title": "Stik",
+            "icon_url": "",
+            "screenshots": [],
+            "official_site": "https://stik.ink",
+            "languages": [
+                "rust",
+                "typescript"
+            ]
         }
 
     ]


### PR DESCRIPTION
## What is Stik?

[Stik](https://stik.ink) is an instant thought capture app for macOS. Press a global hotkey, a post-it note appears, type your thought, close it — done. Notes are stored as plain markdown files in `~/Documents/Stik/`.

- **Open source**: [github.com/0xMassi/stik_app](https://github.com/0xMassi/stik_app) (MIT license)
- **Free**: No account, no cloud, no subscription
- **Built with**: Tauri 2.0 (Rust backend + TypeScript/React frontend)
- **Website**: [stik.ink](https://stik.ink)
- **Installable via**: `brew install --cask 0xmassi/stik/stik` or GitHub Releases

## Checklist

- [x] Searched for duplicates — Stik is not currently listed
- [x] Edited `applications.json` (not README.md)
- [x] Category: `notes`
- [x] Description ends with a full stop/period
- [x] Languages: `rust`, `typescript`
- [x] Has recent commits and English README
- [x] MIT license