### PR TITLE
Add M-Courtyard: LLM fine-tuning app for macOS (Apple Silicon)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7205,7 +7205,7 @@ You can see in which language an app is written. Currently there are following l
   </p>
   </details>
 
-- [M-Courtyard](https://github.com/tuwenbo0120/m-courtyard) - Fine-tune LLMs on your Mac with zero code. Full pipeline from documents to Ollama models, powered by Apple MLX.
+- [M-Courtyard](https://github.com/Mcourtyard/m-courtyard) - Fine-tune LLMs on your Mac with zero code. Full pipeline from documents to Ollama models, powered by Apple MLX.
 
   <details>
   <summary>More</summary>
@@ -7213,11 +7213,11 @@ You can see in which language an app is written. Currently there are following l
 
   **Languages:** <img src='./icons/typescript-16.png' alt='TypeScript icon' title='TypeScript' height='16'/> <img src='./icons/rust-16.png' alt='Rust icon' title='Rust' height='16'/> <img src='./icons/python-16.png' alt='Python icon' title='Python' height='16'/> 
 
-  **Links:** <a href='https://github.com/tuwenbo0120/m-courtyard/releases/latest'><img src='https://img.shields.io/github/v/release/tuwenbo0120/m-courtyard?display_name=tag&sort=semver' alt='Latest Release'/></a> &nbsp; <a href='https://github.com/tuwenbo0120/m-courtyard'><img src='https://img.shields.io/github/stars/tuwenbo0120/m-courtyard?style=social' alt='GitHub stars'/></a> &nbsp; <img src='https://img.shields.io/github/license/tuwenbo0120/m-courtyard' alt='License'/>
+  **Links:** <a href='https://github.com/Mcourtyard/m-courtyard/releases/latest'><img src='https://img.shields.io/github/v/release/Mcourtyard/m-courtyard?display_name=tag&sort=semver' alt='Latest Release'/></a> &nbsp; <a href='https://github.com/Mcourtyard/m-courtyard'><img src='https://img.shields.io/github/stars/Mcourtyard/m-courtyard?style=social' alt='GitHub stars'/></a> &nbsp; <img src='https://img.shields.io/github/license/Mcourtyard/m-courtyard' alt='License'/>
 
   **Screenshots:**
 
-  <img src='https://raw.githubusercontent.com/tuwenbo0120/m-courtyard/main/docs/screenshots/dashboard.png' width='400' loading='lazy'/>
+  <img src='https://raw.githubusercontent.com/Mcourtyard/m-courtyard/main/docs/screenshots/dashboard.png' width='400' loading='lazy'/>
 
   </p>
   </details>


### PR DESCRIPTION
## M-Courtyard

A desktop app for fine-tuning large language models on Apple Silicon Macs with zero code.

**What it does:**
- Import documents → AI generates training data (via Ollama) → LoRA fine-tune (via mlx-lm) → Test → One-click export to Ollama
- 100% local, no cloud, no API keys
- Real-time training visualization with loss curves
- Supports Qwen, DeepSeek, GLM, Llama, and more from mlx-community

**Tech stack:** Tauri 2.x (Rust) + React (TypeScript) + mlx-lm (Python)

**Requirements:** macOS 14+, Apple Silicon (M1/M2/M3/M4)

**License:** AGPL 3.0

**GitHub:** https://github.com/Mcourtyard/m-courtyard

**Category:** Other

Follows the existing entry format with languages, badges, and screenshot.