### PR TITLE
Add Ports - menu bar port viewer/manager

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11066,6 +11066,21 @@
             "languages": [
                 "python"
             ]
+        },
+        {
+            "title": "Ports",
+            "short_description": "macOS menu bar port viewer and manager.",
+            "categories": [
+                "utilities",
+                "menubar"
+            ],
+            "repo_url": "https://github.com/CorvidLabs/Ports",
+            "icon_url": "",
+            "screenshots": [],
+            "official_site": "https://github.com/CorvidLabs/Ports",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Project URL
https://github.com/CorvidLabs/Ports

## Category
utilities, menubar

## Description
Ports is a macOS menu bar port viewer and manager. Built with Swift and SwiftUI, it lets you view and manage active network ports directly from the menu bar. MIT licensed.

## Why it should be included to `Awesome macOS open source applications` (optional)
Ports provides a convenient way to monitor and manage network ports from the macOS menu bar, which is useful for developers and system administrators. It's a native Swift/SwiftUI app that's open source under the MIT license.

## Checklist
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English