### PR TITLE
Add Clip

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11066,6 +11066,21 @@
             "languages": [
                 "python"
             ]
+        },
+	{
+            "title": "Clip",
+            "short_description": "Lightweight clipboard history manager that lives in your menu bar. Tracks text, URLs, and images with pin support.",
+            "categories": [
+                "utilities",
+                "menubar"
+            ],
+            "repo_url": "https://github.com/corvid-agent/Clip",
+            "icon_url": "",
+            "screenshots": [],
+            "official_site": "https://github.com/corvid-agent/Clip",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Adds [Clip](https://github.com/corvid-agent/Clip) to the list.

Clip is a lightweight clipboard history manager that lives in your macOS menu bar. It tracks text, URLs, and images with pin support.

- **Language:** Swift
- **Category:** Utilities, Menubar