### PR TITLE
Add Resolve

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11066,6 +11066,21 @@
             "languages": [
                 "python"
             ]
+        },
+	{
+            "title": "Resolve",
+            "short_description": "DNS lookup and network diagnostics tool in your menu bar. Forward/reverse DNS, MX/NS/CNAME records, and network info.",
+            "categories": [
+                "utilities",
+                "menubar"
+            ],
+            "repo_url": "https://github.com/corvid-agent/Resolve",
+            "icon_url": "",
+            "screenshots": [],
+            "official_site": "https://github.com/corvid-agent/Resolve",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Adds [Resolve](https://github.com/corvid-agent/Resolve) to the list.

Resolve is a DNS lookup and network diagnostics tool in your macOS menu bar. It supports forward/reverse DNS, MX/NS/CNAME records, and network info.

- **Language:** Swift
- **Category:** Utilities, Menubar