### PR TITLE
Add DevKit

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11066,6 +11066,21 @@
             "languages": [
                 "python"
             ]
+        },
+	{
+            "title": "DevKit",
+            "short_description": "Developer toolkit in your menu bar with JSON formatter, Base64 encoder, URL encoder, UUID generator, hash calculator, regex tester, timestamp converter, and color converter.",
+            "categories": [
+                "development",
+                "menubar"
+            ],
+            "repo_url": "https://github.com/corvid-agent/DevKit",
+            "icon_url": "",
+            "screenshots": [],
+            "official_site": "https://github.com/corvid-agent/DevKit",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Adds [DevKit](https://github.com/corvid-agent/DevKit) to the list.

DevKit is a developer toolkit in your macOS menu bar with JSON formatter, Base64 encoder, URL encoder, UUID generator, hash calculator, regex tester, timestamp converter, and color converter.

- **Language:** Swift
- **Category:** Development, Menubar