### PR TITLE
Add Beacon - macOS menu bar system health monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -5150,7 +5150,7 @@ You can see in which language an app is written. Currently there are following l
 <div align="right"><a href="#contents">⬆️ Back to Top</a></div>
 
 <a id="menubar"></a>
-### 📊 Menubar (51)
+### 📊 Menubar (52)
 - [Airpass](https://github.com/alvesjtiago/airpass) - Status bar Mac application to overcome time constrained WiFi networks. 
 
   **Languages:** <img src='./icons/javascript-64.png' alt='JavaScript icon' title='JavaScript' height='16'/> JavaScript 
@@ -5226,6 +5226,12 @@ You can see in which language an app is written. Currently there are following l
 
   </p>
   </details>
+
+- [Beacon](https://github.com/corvid-agent/Beacon) - System health monitor for macOS menu bar with CPU, memory, disk, network, and battery monitoring.
+
+  **Languages:** <img src='./icons/swift-64.png' alt='Swift icon' title='Swift' height='16'/> Swift
+
+  **Badges:** <a href='https://github.com/corvid-agent/Beacon/releases/latest'><img src='https://img.shields.io/github/v/release/corvid-agent/Beacon?display_name=tag&sort=semver' alt='Latest Release'/></a> &nbsp; <a href='https://github.com/corvid-agent/Beacon'><img src='https://img.shields.io/github/stars/corvid-agent/Beacon?style=social' alt='GitHub stars'/></a> &nbsp; <img src='https://img.shields.io/github/last-commit/corvid-agent/Beacon' alt='Last commit'/> &nbsp; <img src='https://img.shields.io/github/license/corvid-agent/Beacon' alt='License'/>
 
 - [Bye-AppQuit](https://github.com/designsbymuzeer/Bye-Mac-App) - A minimal native macOS app to quickly view and Bulk kill running processes.
 

--- a/applications.json
+++ b/applications.json
@@ -230,7 +230,21 @@
           "languages": [
             "typescript"
           ]
-        },   
+        },
+        {
+          "short_description": "System health monitor for macOS menu bar with CPU, memory, disk, network, and battery monitoring.",
+          "categories": [
+            "menubar"
+          ],
+          "repo_url": "https://github.com/corvid-agent/Beacon",
+          "title": "Beacon",
+          "icon_url": "",
+          "screenshots": [],
+          "official_site": "https://github.com/corvid-agent/Beacon",
+          "languages": [
+            "swift"
+          ]
+        },
 		{
 		  "short_description": "A minimal native macOS app to quickly view and Bulk kill running processes.",
 		  "categories": [


### PR DESCRIPTION
## Summary

- Adds [Beacon](https://github.com/corvid-agent/Beacon) to the Menubar section
- Beacon is a macOS system health monitor that lives in the menu bar, built with Swift 6.0 and SwiftUI
- Features: CPU, memory, disk, network, battery, and uptime monitoring with color-coded status indicators (green/yellow/red)
- Requires macOS 13+
- Entry added in alphabetical order and also added to `applications.json`

## Checklist

- [x] App is open source
- [x] Added to correct category (Menubar)
- [x] Entry follows existing format (description, languages, badges)
- [x] Alphabetical order maintained
- [x] Updated `applications.json`
- [x] Updated section count (51 → 52)