### PR TITLE
Add Poirot to Development

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11081,6 +11081,20 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "Poirot",
+            "short_description": "A macOS companion app for browsing Claude Code sessions, exploring diffs, and re-running commands.",
+            "categories": [
+                "development"
+            ],
+            "repo_url": "https://github.com/LeonardoCardoso/Poirot",
+            "icon_url": "",
+            "screenshots": [],
+            "official_site": "https://poirot.fyi",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Poirot is an open source macOS app for browsing Claude Code sessions. It reads local JSONL transcripts and shows conversations, tool blocks, diffs, and lets you re-run commands. Built with Swift 6, SwiftUI, and the Observation framework. MIT licensed.

https://github.com/LeonardoCardoso/Poirot