### PR TITLE
Add ClaudeUsageBar — Claude.ai usage limits in macOS menu bar

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -251,6 +251,23 @@
 		  ]
 		},
         {
+            "title": "ClaudeUsageBar",
+            "short_description": "See your Claude.ai and ChatGPT usage limits live in your macOS menu bar.",
+            "categories": [
+                "menubar",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/yagcioglutoprak/ClaudeUsageBar",
+            "icon_url": "https://raw.githubusercontent.com/yagcioglutoprak/AIQuotaBar/main/assets/claude_icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/yagcioglutoprak/AIQuotaBar/main/assets/demo.gif"
+            ],
+            "official_site": "https://yagcioglutoprak.github.io/AIQuotaBar/",
+            "languages": [
+                "python"
+            ]
+        },
+        {
             "short_description":"Locally hosted web application that allows you to perform various operations on PDF files",
             "categories":[
                 "utilities"


### PR DESCRIPTION
Adds [ClaudeUsageBar](https://github.com/yagcioglutoprak/ClaudeUsageBar) to the Menubar section.

Free, open-source macOS menu bar app showing Claude.ai session (5-hour) and weekly usage limits in real-time.

- Color-coded: green/yellow/red
- macOS notifications at 80% and 95%
- Zero setup — reads local browser cookies, nothing transmitted
- No Electron, ~900 lines Python
- MIT licensed, one-command install