### PR TITLE
Add AIQuotaBar — Claude.ai + ChatGPT usage tracker menu bar app

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11149,6 +11149,23 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "AIQuotaBar",
+            "short_description": "See your Claude.ai and ChatGPT usage limits live in your macOS menu bar.",
+            "categories": [
+                "menubar"
+            ],
+            "repo_url": "https://github.com/yagcioglutoprak/AIQuotaBar",
+            "icon_url": "https://raw.githubusercontent.com/yagcioglutoprak/AIQuotaBar/main/assets/claude_icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/yagcioglutoprak/AIQuotaBar/main/assets/demo.gif"
+            ],
+            "official_site": "https://yagcioglutoprak.github.io/AIQuotaBar/",
+            "languages": [
+                "python"
+            ]
         }
     ]
 }
+


### PR DESCRIPTION
AIQuotaBar is a macOS menu bar app (Python/rumps) that shows live Claude.ai and ChatGPT usage limits in the menu bar. Zero setup — reads browser cookies locally. MIT licensed, open source.

GitHub: https://github.com/yagcioglutoprak/AIQuotaBar

This PR updates the existing ClaudeUsageBar entry (which was renamed to AIQuotaBar) in the Menubar section with the new name, description, and badge URLs.