### PR TITLE
Add AFK - break reminder app

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11081,6 +11081,22 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "AFK",
+            "short_description": "Lightweight break reminder following the 20-20-20 rule with fullscreen reminders, statistics dashboard, and health exercises.",
+            "categories": [
+                "productivity",
+                "menubar"
+            ],
+            "repo_url": "https://github.com/Harry-kp/afk",
+            "icon_url": "https://raw.githubusercontent.com/Harry-kp/afk/main/landing/assets/icon.png",
+            "screenshots": [],
+            "official_site": "https://afk-app.vercel.app",
+            "languages": [
+                "typescript",
+                "rust"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Add AFK

[AFK](https://github.com/Harry-kp/afk) is a lightweight, open-source break reminder for macOS that follows the 20-20-20 rule. Built with Tauri (Rust + TypeScript).

**Features:** Fullscreen break reminders, configurable timing, statistics dashboard, global keyboard shortcuts, health exercises during breaks, menu bar timer.

- [Website](https://afk-app.vercel.app)
- [GitHub](https://github.com/Harry-kp/afk)
- License: MIT
- Languages: TypeScript, Rust
- Categories: Productivity, Menubar