### PR TITLE
Add LangSwitcher — keyboard layout text converter

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11165,7 +11165,24 @@
             "languages": [
                 "python"
             ]
+        },
+        {
+            "title": "LangSwitcher",
+            "short_description": "Open-source keyboard layout text converter for macOS.",
+            "categories": [
+                "keyboard"
+            ],
+            "repo_url": "https://github.com/reg2005/langSwitcher",
+            "icon_url": "",
+            "screenshots": [
+                "https://raw.githubusercontent.com/reg2005/langSwitcher/main/screenshots/general.png"
+            ],
+            "official_site": "https://reg2005.github.io/langSwitcher/",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }
+
 


### PR DESCRIPTION
Adding [LangSwitcher](https://github.com/reg2005/langSwitcher) to the Keyboard section.

**What it does:** Converts text typed in the wrong keyboard layout via hotkey (⇧⇧). Select mistyped text, double-tap Shift, and it's instantly converted to the correct layout.

- Pure Swift, zero dependencies
- Supports EN, RU, DE, FR, ES layouts
- Smart greedy detection of where wrong layout begins
- Privacy-first: no network, no telemetry
- MIT licensed
- macOS 13+ (Ventura)

GitHub: https://github.com/reg2005/langSwitcher
Website: https://reg2005.github.io/langSwitcher/