### PR TITLE
Add ClearDisk to System section

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11181,8 +11181,26 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "ClearDisk",
+            "short_description": "Visualize and clean developer caches to reclaim disk space on macOS.",
+            "categories": [
+                "system",
+                "menubar"
+            ],
+            "repo_url": "https://github.com/bysiber/cleardisk",
+            "icon_url": "",
+            "screenshots": [
+                "https://raw.githubusercontent.com/bysiber/cleardisk/main/assets/showcase.png"
+            ],
+            "official_site": "https://bysiber.github.io/cleardisk",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }
+
 
 


### PR DESCRIPTION
## Add ClearDisk to System section

[ClearDisk](https://github.com/bysiber/cleardisk) is a free, open-source macOS utility built with Swift and SwiftUI that helps developers reclaim disk space by visualizing and cleaning development-related caches.

### Details
- **Category:** System (disk cleaning for developers)
- **Language:** Swift
- **License:** MIT
- **Targets:** Xcode DerivedData, node_modules, CocoaPods, Swift Package Manager caches
- **Requirements:** macOS 14 (Sonoma) or later

Added in alphabetical order between Clean-Me and Diagnostics. Updated section count from 24 to 25.
