### PR TITLE
Add Captain's Log

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11081,6 +11081,24 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "short_description": "Pirate-themed macOS menu bar app that gamifies your dev velocity. Stop committing and your ship sinks.",
+            "categories": [
+                "menubar",
+                "git",
+                "productivity"
+            ],
+            "repo_url": "https://github.com/JungHoonGhae/captains-log",
+            "title": "Captain's Log",
+            "icon_url": "",
+            "screenshots": [
+                "https://raw.githubusercontent.com/JungHoonGhae/captains-log/main/assets/social-preview.png"
+            ],
+            "official_site": "https://github.com/JungHoonGhae/captains-log",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Added [Captain's Log](https://github.com/JungHoonGhae/captains-log) to the list.

**Categories:** Menubar, Git, Productivity

**Description:** Pirate-themed macOS menu bar app that gamifies your dev velocity. Stop committing and your ship sinks.

- Built with Swift / SwiftUI
- Open source (MIT)
- Available via Homebrew
- Active development with recent commits
- English README

Edited `applications.json` as per contributing guidelines.