### PR TITLE
Add TailBar

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11081,6 +11081,21 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "short_description": "Tailscale menu bar app for macOS. Manage servers, peers, and exit nodes from your menu bar.",
+            "categories": [
+                "menubar",
+                "networking"
+            ],
+            "repo_url": "https://github.com/JungHoonGhae/TailBar",
+            "title": "TailBar",
+            "icon_url": "",
+            "screenshots": [],
+            "official_site": "https://github.com/JungHoonGhae/TailBar",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Added [TailBar](https://github.com/JungHoonGhae/TailBar) to the list.

**Categories:** Menubar, Networking

**Description:** Tailscale menu bar app for macOS. Manage servers, peers, and exit nodes from your menu bar.

- Built with Swift / SwiftUI
- Open source (MIT)
- Available via Homebrew
- Active development with recent commits
- English README

Edited `applications.json` as per contributing guidelines.