### PR TITLE
Add ScreenTranslate to Utilities

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11198,9 +11198,24 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "ScreenTranslate",
+            "short_description": "Capture any area or select text to translate instantly, fully on-device with Apple Vision OCR and Apple Translation.",
+            "categories": [
+                "utilities"
+            ],
+            "repo_url": "https://github.com/hcmhcs/screenTranslate",
+            "icon_url": "https://raw.githubusercontent.com/hcmhcs/screenTranslate/main/ScreenTranslate/Assets.xcassets/AppIcon.appiconset/icon_128x128.png",
+            "screenshots": [],
+            "official_site": "https://screentranslate.filient.ai",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }
+
 
 
 


### PR DESCRIPTION
## What is ScreenTranslate?

[ScreenTranslate](https://screentranslate.filient.ai/) is a free, open-source macOS menu bar app that translates any text on your screen instantly.

### Features
- Two translation modes: screen capture (OCR + translate) and text selection (no OCR needed)
- Fully on-device via Apple Vision + Apple Translation — no servers, no tracking
- 20 languages with auto-detect, works offline
- Built natively with Swift 6 and SwiftUI
- Requires macOS 15 (Sequoia) or later
- GPL-3.0

GitHub: https://github.com/hcmhcs/screenTranslate
Website: https://screentranslate.filient.ai

### Checklist
- [x] Added in alphabetical order in the Utilities section
- [x] Follows the existing format with Languages, Website, and Badges
- [x] Open-source (GPL-3.0 License)
- [x] Free to use
- [x] Native macOS application (Swift)