### PR TITLE
Add Fazm - AI computer agent for macOS

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11231,9 +11231,26 @@
             "languages": [
                 "typescript"
             ]
+        },
+        {
+            "title": "Fazm",
+            "short_description": "The fastest AI computer agent for macOS. Takes voice commands and controls your entire desktop.",
+            "categories": [
+                "productivity",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/m13v/fazm",
+            "icon_url": "",
+            "screenshots": [],
+            "official_site": "https://fazm.ai",
+            "languages": [
+                "swift",
+                "typescript"
+            ]
         }
     ]
 }
+
 
 
 


### PR DESCRIPTION
## Summary

Adding [Fazm](https://github.com/m13v/fazm) to the applications list.

Fazm is an open-source AI computer agent for macOS that takes voice commands and controls your entire desktop - clicking, typing, navigating browsers, writing code, managing documents, and operating Google Apps. It uses direct DOM control instead of screenshots for native speed and builds a personal knowledge graph. Open source, local-first, and free.

- **GitHub:** https://github.com/m13v/fazm
- **Website:** https://fazm.ai
- **Languages:** Swift, TypeScript
- **Categories:** Productivity, Utilities

Changes made to `applications.json` as per the contribution guidelines.