### PR TITLE
Add R2Drop - Native macOS menu bar uploader for Cloudflare R2

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11295,6 +11295,22 @@
             "languages": [
                 "python"
             ]
+        },
+        {
+            "title": "R2Drop",
+            "short_description": "Native macOS menu bar application for uploading files to Cloudflare R2 storage.",
+            "categories": [
+                "menubar",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/superhumancorp/r2drop",
+            "icon_url": "",
+            "screenshots": [],
+            "official_site": "https://r2drop.com",
+            "languages": [
+                "swift",
+                "rust"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## R2Drop

[R2Drop](https://github.com/superhumancorp/r2drop) is a native macOS menu bar application for uploading files to Cloudflare R2 storage, built with Swift and Rust.

**Key features:**
- Native macOS menu bar app
- Drag-and-drop file uploads
- Automatic URL copying to clipboard
- Multiple bucket management
- Built with Swift + Rust for performance

**Website:** https://r2drop.com
**GitHub:** https://github.com/superhumancorp/r2drop

Added to the Utilities section in alphabetical order.