### PR TITLE
Add Lockpaw

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11081,6 +11081,22 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "Lockpaw",
+            "short_description": "Lockpaw locks the screen while letting background tasks, builds, and AI agents keep running underneath. Native macOS menu bar app.",
+            "categories": [
+                "security",
+                "menubar",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/sorkila/lockpaw",
+            "icon_url": "https://raw.githubusercontent.com/sorkila/lockpaw/main/Lockpaw/Assets.xcassets/AppIcon.appiconset/icon_512x512%402x.png",
+            "screenshots": [],
+            "official_site": "https://getlockpaw.com",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Project URL
https://github.com/sorkila/lockpaw

## Category
security, menubar, utilities

## Description
Lockpaw locks the screen while letting background tasks, builds, and AI agents keep running underneath. Native macOS menu bar app built with Swift/SwiftUI.

Official site: https://getlockpaw.com

## Checklist
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English