### PR TITLE
Add Claude Usage Monitor to applications.json

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -3507,7 +3507,7 @@
             ]
         },
         {
-            "short_description": "The DOS game emulator that’s fit for your Mac.",
+            "short_description": "The DOS game emulator that\u2019s fit for your Mac.",
             "categories": [
                 "games"
             ],
@@ -3837,7 +3837,7 @@
             ]
         },
         {
-            "short_description": "CodeEdit App for macOS – Elevate your code editing experience. Open source, free forever.",
+            "short_description": "CodeEdit App for macOS \u2013 Elevate your code editing experience. Open source, free forever.",
             "categories": [
                 "ide",
                 "editors"
@@ -4299,7 +4299,7 @@
             ]
         },
         {
-            "short_description": "💌 A beautiful, fast and maintained fork of @nylas Mail by one of the original authors",
+            "short_description": "\ud83d\udc8c A beautiful, fast and maintained fork of @nylas Mail by one of the original authors",
             "categories": [
                 "mail"
             ],
@@ -5804,7 +5804,7 @@
             ]
         },
         {
-            "short_description": "macOS app to block your own access to distracting websites etc for a predetermined period of time. It can not be undone by the app or by a restart – you must wait for the timer to run out. ",
+            "short_description": "macOS app to block your own access to distracting websites etc for a predetermined period of time. It can not be undone by the app or by a restart \u2013 you must wait for the timer to run out. ",
             "categories": [
                 "productivity"
             ],
@@ -7312,7 +7312,7 @@
                 "utilities"
             ],
             "repo_url": "https://github.com/felixhageloh/uebersicht",
-            "title": "Übersicht",
+            "title": "\u00dcbersicht",
             "icon_url": "",
             "screenshots": [],
             "official_site": "",
@@ -7349,7 +7349,7 @@
             ]
         },
         {
-            "short_description": "Wireshark is the world’s foremost and widely-used network protocol analyzer. It lets you see what’s happening on your network at a microscopic level and is the de facto (and often de jure) standard across many commercial and non-profit enterprises, government agencies, and educational institutions. ",
+            "short_description": "Wireshark is the world\u2019s foremost and widely-used network protocol analyzer. It lets you see what\u2019s happening on your network at a microscopic level and is the de facto (and often de jure) standard across many commercial and non-profit enterprises, government agencies, and educational institutions. ",
             "categories": [
                 "utilities"
             ],
@@ -8203,7 +8203,7 @@
             ]
         },
         {
-            "short_description": "💻 Medis is a beautiful, easy-to-use Mac database management application for Redis.",
+            "short_description": "\ud83d\udcbb Medis is a beautiful, easy-to-use Mac database management application for Redis.",
             "categories": [
                 "database"
             ],
@@ -9357,7 +9357,7 @@
             ]
         },
         {
-            "short_description": "Cross-platform open source database management tool for Redis ®",
+            "short_description": "Cross-platform open source database management tool for Redis \u00ae",
             "categories": [
                 "database"
             ],
@@ -9500,7 +9500,7 @@
                 "utilities"
             ],
             "repo_url": "https://github.com/relikd/barss",
-            "title": "baRSS – Menu Bar RSS Reader",
+            "title": "baRSS \u2013 Menu Bar RSS Reader",
             "icon_url": "https://raw.githubusercontent.com/relikd/baRSS/main/baRSS/Artwork/application-icon.svg",
             "screenshots": [
                 "https://raw.githubusercontent.com/relikd/baRSS/main/screenshot.png"
@@ -9564,7 +9564,7 @@
             ]
         },
         {
-            "short_description": "🧾 Your daily journal app, diary or anything else to unclutter your mind. Let linked help you get focused by writing down what is in your mind on a daily basis. ",
+            "short_description": "\ud83e\uddfe Your daily journal app, diary or anything else to unclutter your mind. Let linked help you get focused by writing down what is in your mind on a daily basis. ",
             "categories": [
                 "productivity",
                 "notes",
@@ -9900,7 +9900,7 @@
             ]
         },
         {
-            "short_description": "🏈 Cache CocoaPods for faster rebuild and indexing Xcode project.",
+            "short_description": "\ud83c\udfc8 Cache CocoaPods for faster rebuild and indexing Xcode project.",
             "categories": [
                 "utilities"
             ],
@@ -10198,7 +10198,7 @@
         },
         {
             "title": "M-Courtyard",
-            "short_description": "Desktop app for fine-tuning LLMs on Apple Silicon Macs with zero code. Import documents, generate training datasets with AI, LoRA fine-tune, test, and export to Ollama — entirely offline.",
+            "short_description": "Desktop app for fine-tuning LLMs on Apple Silicon Macs with zero code. Import documents, generate training datasets with AI, LoRA fine-tune, test, and export to Ollama \u2014 entirely offline.",
             "categories": [
                 "development"
             ],
@@ -10316,7 +10316,7 @@
             ]
         },
         {
-            "short_description": "Wireshark is the world’s foremost and widely-used network protocol analyzer. It lets you see what’s happening on your network at a microscopic level and is the de facto (and often de jure) standard across many commercial and non-profit enterprises, government agencies, and educational institutions.",
+            "short_description": "Wireshark is the world\u2019s foremost and widely-used network protocol analyzer. It lets you see what\u2019s happening on your network at a microscopic level and is the de facto (and often de jure) standard across many commercial and non-profit enterprises, government agencies, and educational institutions.",
             "categories": [
                 "system"
             ],
@@ -10349,7 +10349,7 @@
             ]
         },
         {
-            "short_description": "Widelands is a free, open source real-time strategy game with singleplayer campaigns and a multiplayer mode. The game was inspired by Settlers II™ (© Bluebyte) but has significantly more variety and depth to it.",
+            "short_description": "Widelands is a free, open source real-time strategy game with singleplayer campaigns and a multiplayer mode. The game was inspired by Settlers II\u2122 (\u00a9 Bluebyte) but has significantly more variety and depth to it.",
             "categories": [
                 "games"
             ],
@@ -10446,7 +10446,7 @@
             ]
         },
         {
-            "short_description": "MacOS menu bar app for launching iOS  and Android 🤖 emulators.",
+            "short_description": "MacOS menu bar app for launching iOS \uf8ff and Android \ud83e\udd16 emulators.",
             "categories": [
                 "menubar"
             ],
@@ -11310,6 +11310,21 @@
             "languages": [
                 "swift",
                 "rust"
+            ]
+        },
+        {
+            "title": "Claude Usage Monitor",
+            "short_description": "Native macOS menu bar app that tracks Claude.ai usage with colour-coded icons and reset timers.",
+            "categories": [
+                "utilities",
+                "menubar"
+            ],
+            "repo_url": "https://github.com/theDanButuc/Claude-Usage-Monitor",
+            "icon_url": "https://raw.githubusercontent.com/theDanButuc/Claude-Usage-Monitor/main/ClaudeUsageMonitor/Assets/AppIcon_128.png",
+            "screenshots": [],
+            "official_site": "https://github.com/theDanButuc/Claude-Usage-Monitor",
+            "languages": [
+                "swift"
             ]
         }
     ]


### PR DESCRIPTION
## Project URL
https://github.com/theDanButuc/Claude-Usage-Monitor

## Category
utilities, menubar

## Description
Claude Usage Monitor is a native macOS menu bar app that tracks your Claude.ai usage at a glance. It shows a colour-coded icon (green/yellow/red) based on usage level, a live counter in the menu bar, and a reset timer. Built with Swift and SwiftUI. No API key needed — it reads usage data directly from your Claude.ai session.

## Why it should be included to 'Awesome macOS open source applications' (optional)
Claude.ai is widely used by developers, and there is no built-in way to monitor usage limits from the desktop. This lightweight, open-source menu bar utility fills that gap with a native macOS experience.

## Checklist
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- - [X] Only one project/change is in this pull request
- - [X] Screenshot(s) added if any
- - [X] Has a commit from less than 2 years ago
- - [X] Has a **clear** README in English