### PR TITLE
Add Mocker - Docker-compatible container CLI for macOS

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,21 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "Mocker",
+            "short_description": "Docker-compatible container CLI for macOS, built on Apple's Containerization framework.",
+            "categories": [
+                "development",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/us/mocker",
+            "icon_url": "",
+            "screenshots": [],
+            "official_site": "https://github.com/us/mocker",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Summary

Add [Mocker](https://github.com/us/mocker) to the applications list.

**Mocker** is a Docker-compatible container CLI for macOS, built on Apple's Containerization framework. It provides a familiar Docker CLI experience (`mocker run`, `mocker build`, `mocker compose`) using native macOS virtualization — no Docker Desktop or VM required.

- **Language:** Swift
- **License:** AGPL-3.0
- **Categories:** Development, Utilities
- **Repo:** https://github.com/us/mocker

## Changes

- Added Mocker entry to `applications.json`