### PR TITLE
Adds Vision Framework Explorer

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11090,13 +11090,13 @@
                 "ios--macos",
                 "utilities"
             ],
-            "repo_url": "https://github.com/cristidbr/vision_framework_explorer",
+            "repo_url": "https://github.com/cristidbr/vision-framework-explorer",
             "title": "Vision Fraemwork Explorer",
-            "icon_url": "https://raw.githubusercontent.com/cristidbr/vision_framework_explorer/refs/heads/main/Resources/app_icon.png",
+            "icon_url": "https://raw.githubusercontent.com/cristidbr/vision-framework-explorer/refs/heads/main/Resources/app_icon.png",
             "screenshots": [
-                "https://raw.githubusercontent.com/cristidbr/vision_framework_explorer/refs/heads/main/Resources/app_preview_dual_appearance.png"  
+                "https://raw.githubusercontent.com/cristidbr/vision-framework-explorer/refs/heads/main/Resources/app_preview_dual_appearance.png"  
             ],
-            "official_site": "https://github.com/cristidbr/vision_framework_explorer",
+            "official_site": "https://github.com/cristidbr/vision-framework-explorer",
             "languages": [
                 "swift"
             ]

--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,24 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "short_description": "An app to explore native Vision Framework capabilities.",
+            "categories": [
+                "development",
+                "ios--macos",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/cristidbr/vision_framework_explorer",
+            "title": "Vision Fraemwork Explorer",
+            "icon_url": "https://raw.githubusercontent.com/cristidbr/vision_framework_explorer/refs/heads/main/Resources/app_icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/cristidbr/vision_framework_explorer/refs/heads/main/Resources/app_preview_dual_appearance.png"  
+            ],
+            "official_site": "https://github.com/cristidbr/vision_framework_explorer",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Project URL
https://github.com/cristidbr/vision_framework_explorer

## Category
development, vision, utilities

## Description
An app to explore native Vision Framework capabilities on iOS and macOS.

## Why it should be included to `Awesome macOS open source applications ` (optional)
Quickly check native OCR recognition functions.

## Checklist
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English
