### PR TITLE
Add RightLayout — AI keyboard layout fixer

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,20 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "RightLayout",
+            "short_description": "AI keyboard layout fixer that auto-corrects wrong keyboard layout (EN/RU/HE) as you type using CoreML.",
+            "categories": [
+                "keyboard"
+            ],
+            "repo_url": "https://github.com/chernistry/RightLayout-src",
+            "icon_url": "",
+            "screenshots": [],
+            "official_site": "https://alexchernysh.com/rightlayout",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Project URL
https://github.com/chernistry/RightLayout

## Category
keyboard

## Description
RightLayout is an AI-powered keyboard layout fixer for macOS. It automatically detects and corrects text typed in the wrong keyboard layout (English, Russian, Hebrew) as you type, using an on-device CoreML model. Written in Swift.

**Website:** https://alexchernysh.com/rightlayout

## Checklist
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English