### PR TITLE
Add Repose

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,24 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "short_description": "Break reminder for macOS that automatically pauses during meetings.",
+            "categories": [
+                "productivity",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/fikrikarim/repose",
+            "title": "Repose",
+            "icon_url": "https://raw.githubusercontent.com/fikrikarim/repose/main/assets/icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/fikrikarim/repose/main/assets/break-overlay.png",
+                "https://raw.githubusercontent.com/fikrikarim/repose/main/assets/menu.png"
+            ],
+            "official_site": "https://github.com/fikrikarim/repose",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }

--- a/applications.json
+++ b/applications.json
@@ -11401,6 +11401,24 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "Repose",
+            "short_description": "Break reminder for macOS that automatically pauses during meetings.",
+            "categories": [
+                "productivity",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/fikrikarim/repose",
+            "icon_url": "https://raw.githubusercontent.com/fikrikarim/repose/main/assets/icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/fikrikarim/repose/main/assets/break-overlay.png",
+                "https://raw.githubusercontent.com/fikrikarim/repose/main/assets/menu.png"
+            ],
+            "official_site": "https://github.com/fikrikarim/repose",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Description

Adding [Repose](https://github.com/fikrikarim/repose), a free and open-source macOS menu bar app that reminds you to take regular breaks from your screen with automatic meetings detection.

- Built with Swift/SwiftUI
- MIT licensed
- macOS 13+
- Configurable work intervals and break durations
- Smart idle detection