### PR TITLE
Add Command Reopen

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -7993,6 +7993,21 @@
         {
             "short_description": "Slate is a window management application similar to Divvy and SizeUp",
             "categories": [
+        {
+            "title": "Command Reopen",
+            "short_description": "Fix Cmd+Tab for minimized and closed windows on macOS. Auto-restore windows with zero permissions required.",
+            "categories": [
+                "window-management",
+                "productivity"
+            ],
+            "repo_url": "https://github.com/fchen6611/command-reopen",
+            "icon_url": "",
+            "screenshots": [],
+            "official_site": "https://commandreopen.com",
+            "languages": [
+                "swift"
+            ]
+        },
                 "window-management"
             ],
             "repo_url": "https://github.com/jigish/slate",


### PR DESCRIPTION
## Project
https://github.com/fchen6611/command-reopen

## Categories
- window-management
- productivity

## Description
Command Reopen fixes Cmd+Tab for minimized and closed windows on macOS.

Key features:
- Auto-restore minimized windows on every Cmd+Tab switch
- Zero permissions required (no Accessibility, no Screen Recording)
- Works behind native Cmd+Tab
- Under 2 MB
- Open source

## Checklist
- [x] Edit applications.json instead of README.md
- [x] Only one project/change is in this PR
- [x] Has a commit from less than 2 years ago
- [x] Has a clear README in English