### PR TITLE
Add Tome - local meeting transcription app

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,20 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "short_description": "Local meeting transcription that drops structured markdown into your Obsidian vault. No cloud, no API keys.",
+            "categories": [
+                "audio"
+            ],
+            "repo_url": "https://github.com/Gremble-io/Tome",
+            "title": "Tome",
+            "icon_url": "",
+            "screenshots": [],
+            "official_site": "",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Tome is an open-source macOS app (Swift, MIT license) that captures meetings and voice memos, transcribes them locally using Parakeet-TDT v3 on Apple Silicon, and outputs structured markdown files. No cloud dependency.