### PR TITLE
Add Claudoscope to Menubar category

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,26 @@
             "languages": [
                 "swift"
             ]
+        },
+	{
+            "short_description": "Menu bar app for Claude Code session analytics with real-time secret detection, config health linting, and token/cost tracking.",
+            "categories": [
+                "menubar",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/cordwainersmith/claudoscope",
+            "title": "Claudoscope",
+            "icon_url": "https://claudoscope.com/logo.png",
+            "screenshots": [
+                "https://claudoscope.com/widget.png",
+                "https://claudoscope.com/health.png",
+                "https://claudoscope.com/secret-found.png",
+                "https://claudoscope.com/skills.png"
+            ],
+            "official_site": "https://claudoscope.com/",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
**Project URL:** https://github.com/cordwainersmith/claudoscope
**Category:** Menubar, Utilities
**Description:** Menu bar app for Claude Code session analytics with real-time secret detection, config health linting, and token/cost tracking.

**Why should this project be included?**
Claudoscope is a native Swift/SwiftUI macOS menu bar app that provides session analytics for Claude Code developers. It parses local JSONL files for full-text search, token/cost tracking, real-time secret detection, and config health linting (44 rules). Fully offline, open source (MIT), free.

- [x] I have edited `applications.json` and NOT `README.md`
- [x] Only one project in this PR
- [x] Screenshots added if any
- [x] Project has commits from less than 2 years ago
- [x] Project has a clear README in English