### PR TITLE
Add Revu - local-first macOS spaced repetition app

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,21 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "Revu",
+            "short_description": "Local-first spaced repetition app for macOS with FSRS scheduling, Notion-inspired UI, Anki import, study guides, exams, and forecasting.",
+            "categories": [
+                "notes",
+                "productivity"
+            ],
+            "repo_url": "https://github.com/JuliusBrussee/revu-swift",
+            "icon_url": "https://raw.githubusercontent.com/JuliusBrussee/revu-swift/main/Revu/Revu/Assets.xcassets/AppIcon.appiconset/icon_512x512%402x.png",
+            "screenshots": [],
+            "official_site": "https://revu.cards",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Summary

Adds [Revu](https://revu.cards) to the applications list.

**Revu** is a local-first spaced repetition app for macOS built with SwiftUI. Key features:

- **FSRS scheduling** — modern spaced repetition algorithm for optimal review timing
- **Notion-inspired UI** — clean, block-based interface for creating and organizing flashcards
- **Anki import** — migrate existing decks from Anki (.apkg)
- **Study guides & exams** — structured study modes beyond basic flashcard review
- **Forecasting** — visualize upcoming review workload

**Repo:** https://github.com/JuliusBrussee/revu-swift
**Website:** https://revu.cards
**License:** GPL-3.0
**Language:** Swift (SwiftUI)
**Categories:** Notes, Productivity