### PR TITLE
Add ClearanceKit to security apps

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,20 @@
             "languages": [
                 "swift"
             ]
+        },
+	{
+            "title": "ClearanceKit",
+            "short_description": "File-access control for macOS that protects sensitive user data from supply-chain attacks using Endpoint Security.",
+            "categories": [
+                "security"
+            ],
+            "repo_url": "https://github.com/craigjbass/clearancekit",
+            "icon_url": "https://raw.githubusercontent.com/craigjbass/clearancekit/main/docs/logo.png",
+            "screenshots": [],
+            "official_site": "https://craigjbass.github.io/clearancekit",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Proposed Changes

**[ClearanceKit](https://craigjbass.github.io/clearancekit)** — File-access control for macOS that protects sensitive user data (SSH keys, credentials, messages, browser cookies) from supply-chain attacks. Intercepts file-system operations via Endpoint Security and enforces code-signing-based policies, so a trojanised `npm` package or compromised build tool is denied access even if it runs under your user account.

**Key features:**
- Policies bind to cryptographic signing identities rather than file hashes, surviving software updates indefinitely
- Maintains a live in-memory process tree with cached ancestor chains, enabling ancestry-aware policy rules
- Ships with built-in presets for common apps (Signal, Notes, Contacts, Discord)
- GUI for real-time denied access visibility and one-click allow rule creation
- Supports MDM-managed policy delivery for enterprise deployment

**Category:** Security
**Language:** Swift