### PR TITLE
Add HardwareVisualizer

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -7523,7 +7523,11 @@
             ],
             "repo_url": "https://github.com/shm11C3/HardwareVisualizer",
             "icon_url": "https://raw.githubusercontent.com/shm11C3/HardwareVisualizer/refs/heads/develop/app-icon.png",
-            "screenshots": [],
+            "screenshots": [
+                "https://raw.githubusercontent.com/shm11C3/hardviz-webpage/refs/heads/master/src/assets/screenshots/macos.png",
+                "https://github-production-user-asset-6210df.s3.amazonaws.com/78523393/386857440-ef3e1630-e567-47a1-a437-f9a3981dd587.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20260404%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20260404T045959Z&X-Amz-Expires=300&X-Amz-Signature=2be99672ad79adbeda3f37d2900604c39cf023f12759ff84aac9b0ab07e10de5&X-Amz-SignedHeaders=host",
+                "https://github-production-user-asset-6210df.s3.amazonaws.com/78523393/416148241-dd849d54-37a0-4f00-bec8-9c7f994d49fa.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20260404%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20260404T050011Z&X-Amz-Expires=300&X-Amz-Signature=13248bb92a309a1be5851ae38c45cbffe956c6fa851e9e7a0047f3791788fff5&X-Amz-SignedHeaders=host"
+            ],
             "official_site": "https://hardviz.com/",
             "languages": [
                 "rust",

--- a/applications.json
+++ b/applications.json
@@ -7515,6 +7515,21 @@
             ]
         },
         {
+            "title": "HardwareVisualizer",
+            "short_description": "A cross-platform hardware monitor with real-time metrics, historical insights, and a customizable dashboard.",
+            "categories": [
+                "utilities"
+            ],
+            "repo_url": "https://github.com/shm11C3/HardwareVisualizer",
+            "icon_url": "https://raw.githubusercontent.com/shm11C3/HardwareVisualizer/refs/heads/develop/app-icon.png",
+            "screenshots": [],
+            "official_site": "https://hardviz.com/",
+            "languages": [
+                "rust",
+                "typescript"
+            ]
+        },
+        {
             "short_description": "Catch YouTube into your macOS menu bar! ",
             "categories": [
                 "video"

--- a/applications.json
+++ b/applications.json
@@ -7518,6 +7518,7 @@
             "title": "HardwareVisualizer",
             "short_description": "A cross-platform hardware monitor with real-time metrics, historical insights, and a customizable dashboard.",
             "categories": [
+                "system",
                 "utilities"
             ],
             "repo_url": "https://github.com/shm11C3/HardwareVisualizer",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/shm11C3/HardwareVisualizer

## Category
system, utilities

## Description
HardwareVisualizer is a free and open-source hardware monitoring application for macOS, Windows, and Linux. It provides real-time system metrics, detailed usage graphs, and historical insights so users can track hardware activity both at a glance and over time. The app includes a customizable dashboard, flexible graph themes, and support for background personalization, allowing users to adjust the interface to their preferences. Its goal is to offer a modern and intuitive hardware monitoring experience while remaining transparent and open source.

## Why it should be included to `Awesome macOS open source applications ` (optional)
HardwareVisualizer supports macOS and is actively maintained, but its macOS version is still less visible than its Windows version. Including it in this list would make it easier for macOS users to discover an open-source hardware monitoring app with real-time metrics, historical insights, and a customizable dashboard.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English
