### PR TITLE
Add Anima — Claude Code companion app (Rust/Tauri)

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,22 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "Anima",
+            "short_description": "Native macOS companion for Claude Code with per-project ASCII familiars, nim token economy, and cross-session watcher. Built with Tauri v2.",
+            "categories": [
+                "development",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/btangonan/anima",
+            "icon_url": "",
+            "screenshots": [],
+            "official_site": "https://github.com/btangonan/anima",
+            "languages": [
+                "rust",
+                "javascript"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Anima is a native macOS app I built to extend Claude Code's /buddy companion system.

When Anthropic launched /buddy, I loved the idea but wanted more: per-project companions instead of one per account, a way to earn and unlock new ones, and the ability to actually use buddy observations in my Claude Code sessions.

So I built it. Every project gets its own ASCII companion (8 species, 5 rarity tiers, 80 unique combos), token usage earns in-app currency for re-rolls, and a Rust daemon polls all active sessions to surface observations about your work.

Tauri v2 + Rust backend + vanilla JS frontend. 4MB binary. 43 tests. MIT licensed. First app I've ever shipped.

https://github.com/btangonan/anima