### PR TITLE
Add LiteEdit to Text Editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -3187,6 +3187,14 @@ You can see in which language an app is written. Currently there are following l
   </p>
   </details>
 
+- [LiteEdit](https://github.com/arietan/lite-edit) - Fast, native macOS code editor under 1 MB — built with Swift and AppKit, no Electron.
+
+  **Languages:** <img src='./icons/swift-64.png' alt='Swift icon' title='Swift' height='16'/> Swift 
+
+  **Website:** [https://arietan.github.io/lite-edit/](https://arietan.github.io/lite-edit/)
+
+  **Badges:** <a href='https://github.com/arietan/lite-edit/releases/latest'><img src='https://img.shields.io/github/v/release/arietan/lite-edit?display_name=tag&sort=semver' alt='Latest Release'/></a> &nbsp; <a href='https://github.com/arietan/lite-edit'><img src='https://img.shields.io/github/stars/arietan/lite-edit?style=social' alt='GitHub stars'/></a> &nbsp; <img src='https://img.shields.io/github/last-commit/arietan/lite-edit' alt='Last commit'/> &nbsp; <img src='https://img.shields.io/github/license/arietan/lite-edit' alt='License'/>
+
 - [mxMarkEdit](https://github.com/maxnd/mxMarkEdit) - A visual editor of Markdown document, tasks and tables.
 
   **Languages:** <code>free-pascal</code> 

--- a/applications.json
+++ b/applications.json
@@ -3178,6 +3178,21 @@
             ]
         },
         {
+            "short_description": "Fast, native macOS code editor under 1 MB — built with Swift and AppKit, no Electron.",
+            "categories": [
+                "editors",
+                "text"
+            ],
+            "repo_url": "https://github.com/arietan/lite-edit",
+            "title": "LiteEdit",
+            "icon_url": "",
+            "screenshots": [],
+            "official_site": "https://arietan.github.io/lite-edit/",
+            "languages": [
+                "swift"
+            ]
+        },
+        {
             "short_description": "Lightweight Code Editor (IDE) for macOS. ",
             "categories": [
                 "ide",


### PR DESCRIPTION
## What is LiteEdit?

[LiteEdit](https://arietan.github.io/lite-edit/) is a fast, native macOS code editor built entirely with Swift and AppKit — no Electron, no web views, no third-party dependencies.

- **App size:** < 1 MB
- **RAM at idle:** ~20 MB
- **Runtime:** Native (AppKit + TextKit)
- **Language:** Swift
- **License:** MIT
- **macOS:** 13+

### Changes

- Added LiteEdit to `README.md` in the Text Editors section (alphabetical order)
- Added LiteEdit to `applications.json`

### Links

- Website: https://arietan.github.io/lite-edit/
- Source: https://github.com/arietan/lite-edit
- Download: https://github.com/arietan/lite-edit/releases/latest

Made with [Cursor](https://cursor.com)