### PR TITLE
Add PureMac - open-source macOS cleaner

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,25 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "PureMac",
+            "short_description": "Free macOS cleaner with zero telemetry. Cleans system caches, Xcode junk, Homebrew cache, mail attachments, and finds large or old files. Supports scheduled auto-cleaning.",
+            "categories": [
+                "utilities",
+                "system"
+            ],
+            "repo_url": "https://github.com/momenbasel/PureMac",
+            "icon_url": "https://raw.githubusercontent.com/momenbasel/PureMac/main/PureMac/Assets.xcassets/AppIcon.appiconset/icon_256.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/momenbasel/PureMac/main/screenshots/smart-scan.png",
+                "https://raw.githubusercontent.com/momenbasel/PureMac/main/screenshots/category-view.png",
+                "https://raw.githubusercontent.com/momenbasel/PureMac/main/screenshots/system-junk-detail.png"
+            ],
+            "official_site": "https://github.com/momenbasel/PureMac",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Project URL
https://github.com/momenbasel/PureMac

## Category
utilities, system

## Description
PureMac is a free, open-source macOS cleaner built with SwiftUI (macOS 13+). MIT licensed. Zero telemetry, zero analytics, zero network calls. Cleans system caches, user caches, Xcode junk, mail attachments, Homebrew cache, and purgeable space. Helps find large and old files. Supports scheduled auto-cleaning.

Install via Homebrew: `brew tap momenbasel/tap && brew install --cask puremac`

## Why it should be included to `Awesome macOS open source applications`
- Actively maintained, native SwiftUI app
- Privacy-first: no telemetry, no analytics, no network calls whatsoever
- Covers a category (system cleaners) that has no open-source representation in this list
- MIT licensed
- Clear English README with screenshots

## Checklist
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English