### PR TITLE
Add Kaset to open-source Mac app list

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -4808,6 +4808,25 @@
             ]
         },
         {
+            "short_description": "Native YouTube Music client for macOS.",
+            "categories": [
+                "music",
+                "audio",
+                "player",
+                "streaming"
+            ],
+            "repo_url": "https://github.com/sozercan/kaset",
+            "title": "Kaset",
+            "icon_url": "https://raw.githubusercontent.com/sozercan/kaset/main/Sources/Kaset/Resources/kaset.icon/Assets/Image%20Layer.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/sozercan/kaset/main/docs/screenshot.png"
+            ],
+            "official_site": "",
+            "languages": [
+                "swift"
+            ]
+        },
+        {
             "short_description": "Basic/Classic Hacker News app, used as a Cocoa & Swift learning platform. ",
             "categories": [
                 "news"


### PR DESCRIPTION
## Summary
- add Kaset to `applications.json`
- classify it under music, audio, player, and streaming
- include icon and screenshot URLs from the Kaset repository

## Why
Kaset is an open-source native macOS YouTube Music client built with Swift and SwiftUI, so it fits this list well.

## Validation
- confirmed there was no existing Kaset entry
- ran `git diff --check`