### PR TITLE
feat: add Claude Statistics – native macOS menu bar app for Claude Code usage tracking

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11083,5 +11083,21 @@
                 "swift"
             ]
         }
+	{
+            "title": "Claude Statistics",
+            "short_description": "Native macOS menu bar app for monitoring Claude Code session usage, token costs, and Anthropic subscription limits in real time. Reads local JSONL transcripts from ~/.claude/projects/ with no setup required.",
+            "categories": [
+                "developer-tools",
+                "menubar",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/sj719045032/claude-statistics",
+            "icon_url": "",
+            "screenshots": [],
+            "official_site": "https://github.com/sj719045032/claude-statistics",
+            "languages": [
+                "swift"
+            ]
+        },
     ]
 }


### PR DESCRIPTION
## Summary

Adds **Claude Statistics** to the application list.

**Repo:** https://github.com/sj719045032/claude-statistics
**License:** MIT
**Language:** Swift
**Platform:** macOS 14+
**Categories:** developer-tools, menubar, utilities

## About

Claude Statistics is a native macOS menu bar app for monitoring Claude Code sessions, token usage, and Anthropic subscription costs in real time.

**Key features:**
- Auto-discovers and parses JSONL transcripts from `~/.claude/projects/`
- Daily/weekly/monthly/yearly cost analytics with per-model breakdowns (Opus/Sonnet/Haiku)
- Live subscription usage monitoring (5h/7d windows) with reset countdown
- Built-in transcript viewer with full-text search
- 100% local — no data uploads, uses existing Keychain OAuth token
- SwiftUI + AppKit hybrid, menu bar only (no dock icon)
- Sparkle auto-updates