### PR TITLE
Add MakLock

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,21 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "MakLock",
+            "short_description": "Free macOS menu bar app that locks applications with Touch ID, Apple Watch proximity, or password using a full-screen blur overlay.",
+            "categories": [
+                "security",
+                "menubar"
+            ],
+            "repo_url": "https://github.com/dutkiewiczmaciej/MakLock",
+            "icon_url": "",
+            "screenshots": [],
+            "official_site": "https://dutkiewiczmaciej.github.io/MakLock/",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
MakLock is a free, open-source macOS menu bar app that locks applications with Touch ID, Apple Watch proximity, or password. It uses a full-screen blur overlay on all monitors to prevent unauthorized access to protected apps.

- **Language:** Swift
- **License:** MIT
- **Categories:** Security, Menubar
- **Website:** https://dutkiewiczmaciej.github.io/MakLock/
- **Repository:** https://github.com/dutkiewiczmaciej/MakLock