### PR TITLE
Add MakLock

### DIFF
--- a/README.md
+++ b/README.md
@@ -6943,6 +6943,13 @@ You can see in which language an app is written. Currently there are following l
   </p>
   </details>
 
+
+- [MakLock](https://github.com/dutkiewiczmaciej/MakLock) - Lock any macOS app with Touch ID, Apple Watch proximity, or password. Full-screen blur overlay on all monitors.
+
+  **Languages:** <img src='./icons/swift-64.png' alt='Swift icon' title='Swift' height='16'/> Swift 
+
+  **Website:** [https://dutkiewiczmaciej.github.io/MakLock/](https://dutkiewiczmaciej.github.io/MakLock/)
+
 - [Pareto Security](https://github.com/paretoSecurity/pareto-mac/) - A MenuBar app to automatically audit your Mac for basic security hygiene.
 
   **Languages:** <img src='./icons/swift-64.png' alt='Swift icon' title='Swift' height='16'/> Swift 


### PR DESCRIPTION
Add [MakLock](https://github.com/dutkiewiczmaciej/MakLock) to the Security section.

MakLock is a free, open-source macOS menu bar app that locks applications with Touch ID, Apple Watch proximity, or password. It uses a full-screen blur overlay across all monitors.

- Language: Swift/SwiftUI
- License: MIT
- macOS 13+, Universal Binary
- Website: https://dutkiewiczmaciej.github.io/MakLock/