### PR TITLE
Add Clippy

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,25 @@
             "languages": [
                 "swift"
             ]
-        }
+        },
+    {
+        "title": "Clippy",
+        "short_description": "Clipboard manager with content-aware previews, AI transformations, a built-in screenshot editor, and file converter.",
+        "categories": [
+            "productivity",
+            "utilities"
+        ],
+        "repo_url": "https://github.com/yarasaa/Clippy",
+        "icon_url": "https://raw.githubusercontent.com/yarasaa/Clippy/main/docs/screenshots/01-main-popover.png",
+        "screenshots": [
+            "https://raw.githubusercontent.com/yarasaa/Clippy/main/docs/screenshots/01-main-popover.png",
+            "https://raw.githubusercontent.com/yarasaa/Clippy/main/docs/screenshots/14-editor.png",
+            "https://raw.githubusercontent.com/yarasaa/Clippy/main/docs/screenshots/16-file-converter.png"
+        ],
+        "official_site": "https://github.com/yarasaa/Clippy",
+        "languages": [
+            "swift"
+        ]
+    }
     ]
 }


### PR DESCRIPTION
Adds **Clippy** to `applications.json` (per CONTRIBUTING.md), categorized under `productivity` and `utilities`.

## About Clippy
Clippy is an actively maintained open-source (MIT) macOS clipboard manager with:

- Content-aware previews for URLs, colors, JSON, code, images
- AI transformations (Ollama locally, or OpenAI / Anthropic / Google Gemini BYO-key)
- Built-in screenshot editor with 20+ annotation tools and context-aware Inspector
- File format converter (image / document / audio / video / data)
- Windows 11-style dock preview with live thumbnails
- Shelf for drag-and-drop files

Repo: https://github.com/yarasaa/Clippy
License: MIT
Requires: macOS 13+
Language: Swift

## Checklist
- [x] Edited `applications.json` (not README.md) per contributing guidelines
- [x] Categories chosen from `categories.json`: `productivity`, `utilities`
- [x] Title, short_description, repo_url, icon_url, screenshots, official_site, languages all populated
- [x] JSON validated