### PR TITLE
Add TablePro to Database section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1087,7 +1087,7 @@ You can see in which language an app is written. Currently there are following l
   </p>
   </details>
 
-### 🗄️ Database (18)
+### 🗄️ Database (19)
 - [Bdash](https://github.com/bdash-app/bdash) - Simple SQL Client for lightweight data analysis.
 
   **Languages:** <img src='./icons/javascript-64.png' alt='JavaScript icon' title='JavaScript' height='16'/> JavaScript 
@@ -1324,6 +1324,12 @@ You can see in which language an app is written. Currently there are following l
 
   </p>
   </details>
+
+- [TablePro](https://github.com/TableProApp/TablePro) - Native macOS database client for MySQL, PostgreSQL, SQLite, MongoDB, Redis, and 15+ more.
+
+  **Languages:** <img src='./icons/swift-64.png' alt='Swift icon' title='Swift' height='16'/> Swift 
+
+  **Website:** [https://tablepro.app](https://tablepro.app)
 
 ### 👨‍💻 Development (16)
 - [Apache Netbeans](https://github.com/apache/netbeans) - Apache NetBeans is an IDE, Tooling Platform and Application Framework suitable for development in Java, JavaScript, PHP, HTML5, CSS, and more.


### PR DESCRIPTION
Add [TablePro](https://github.com/TableProApp/TablePro) to the Database section.

Native macOS database client built with Swift/SwiftUI. Supports MySQL, PostgreSQL, SQLite, MongoDB, Redis, SQL Server, and 12 more. Free and open-source (AGPLv3).