### PR TITLE
Add TablePro to Database category

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -9428,6 +9428,20 @@
             ]
         },
         {
+            "title": "TablePro",
+            "short_description": "Native macOS database client for MySQL, PostgreSQL, SQLite, MongoDB, Redis, and 15+ more.",
+            "categories": [
+                "database"
+            ],
+            "repo_url": "https://github.com/TableProApp/TablePro",
+            "icon_url": "https://raw.githubusercontent.com/TableProApp/TablePro/main/TablePro/Assets.xcassets/AppIcon.appiconset/icon_256x256.png",
+            "screenshots": [],
+            "official_site": "https://tablepro.app",
+            "languages": [
+                "swift"
+            ]
+        },
+        {
             "short_description": "RSS & Atom feed reader that lives in the system status bar.",
             "categories": [
                 "menubar",


### PR DESCRIPTION
Add TablePro to the Database category via applications.json.

- **Title:** TablePro
- **Repo:** https://github.com/TableProApp/TablePro
- **Site:** https://tablepro.app
- **Language:** Swift
- **Category:** database

Native macOS database client for MySQL, PostgreSQL, SQLite, MongoDB, Redis, and 15+ more. Free and open-source (AGPLv3).