### PR TITLE
Add BrewBar — Homebrew menu bar companion

### DIFF
--- a/README.md
+++ b/README.md
@@ -4424,6 +4424,10 @@ You can see in which language an app is written. Currently there are following l
   </p>
   </details>
 
+- [BrewBar](https://github.com/MoLinesGitHub/Brew-TUI/tree/main/menubar) - macOS menu bar companion for Homebrew — shows outdated package counts, sends notifications, and lets you upgrade without opening a terminal. 
+
+  **Languages:** <img src='./icons/swift-64.png' alt='Swift icon' title='Swift' height='16'/> Swift 
+
 - [Bye-AppQuit](https://github.com/designsbymuzeer/Bye-Mac-App) - A minimal native macOS app to quickly view and Bulk kill running processes.
 
   **Languages:** <img src='./icons/swift-64.png' alt='Swift icon' title='Swift' height='16'/> Swift 

--- a/README.md
+++ b/README.md
@@ -4424,10 +4424,6 @@ You can see in which language an app is written. Currently there are following l
   </p>
   </details>
 
-- [BrewBar](https://github.com/MoLinesGitHub/Brew-TUI/tree/main/menubar) - macOS menu bar companion for Homebrew — shows outdated package counts, sends notifications, and lets you upgrade without opening a terminal. 
-
-  **Languages:** <img src='./icons/swift-64.png' alt='Swift icon' title='Swift' height='16'/> Swift 
-
 - [Bye-AppQuit](https://github.com/designsbymuzeer/Bye-Mac-App) - A minimal native macOS app to quickly view and Bulk kill running processes.
 
   **Languages:** <img src='./icons/swift-64.png' alt='Swift icon' title='Swift' height='16'/> Swift 

--- a/applications.json
+++ b/applications.json
@@ -1112,6 +1112,21 @@
             ]
         },
         {
+            "short_description": "macOS menu bar companion for Homebrew — shows outdated package counts, sends notifications, and lets you upgrade without opening a terminal.",
+            "categories": [
+                "menubar",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/MoLinesGitHub/Brew-TUI/tree/main/menubar",
+            "title": "BrewBar",
+            "icon_url": "",
+            "screenshots": [],
+            "official_site": "https://github.com/MoLinesGitHub/Brew-TUI",
+            "languages": [
+                "swift"
+            ]
+        },
+        {
             "short_description": "Brave browser for Desktop and Laptop computers running Windows, macOS, and Linux. ",
             "categories": [
                 "browser"


### PR DESCRIPTION
**[BrewBar](https://github.com/MoLinesGitHub/Brew-TUI/tree/main/menubar)** — macOS menu bar app (Swift 6 / SwiftUI) that shows outdated Homebrew package counts, sends notifications, and lets you upgrade without opening a terminal.

Added to the Menubar section.