### PR TITLE
Add Bzz

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,23 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "Bzz",
+            "short_description": "Automatic keyboard layout switcher (RU↔EN). Detects mistyped words like \"ghbdtn\" and replaces with \"привет\" on the fly. Open-source replacement for the abandoned Punto Switcher.",
+            "categories": [
+                "utilities",
+                "productivity"
+            ],
+            "repo_url": "https://github.com/zlopixatel/bzz",
+            "icon_url": "",
+            "screenshots": [
+                "https://raw.githubusercontent.com/zlopixatel/bzz/main/docs/demo.gif"
+            ],
+            "official_site": "https://github.com/zlopixatel/bzz",
+            "languages": [
+                "go"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Adds [Bzz](https://github.com/zlopixatel/bzz) — an open-source automatic keyboard layout switcher for macOS, written in Go.

Punto Switcher (the canonical Russian keyboard switcher) was abandoned for macOS in 2017, and the only commercial alternative on Mac (Caramba Switcher) charges a yearly subscription. Bzz fills the gap as a free, MIT-licensed option.

**Highlights:**

- Active CGEventTap (not listen-only) — intercepts Enter before submit, so it works in Slack/Telegram/Notion where the message would otherwise fly out unedited
- 98K Russian dictionary + Snowball stemmer + Levenshtein fuzzy matching (catches typos: `gjljk;bv` → `продолжим`)
- Cmd+Z undo within 5s, with per-app exception learning — RuSwitch self-tunes to never auto-correct words you reject in specific apps
- Cmd+Shift+X manually converts a selection in either direction
- Tray icon (⚡ active / 💤 paused), LaunchAgent auto-start
- 4.7 MB Go binary, no telemetry, no auto-update calls

**Compliance with CONTRIBUTING.md:**
- ✅ Edited `applications.json` (not README.md)
- ✅ Description ends with full stop
- ✅ Recent commits, builds on current Xcode/macOS 12+
- ✅ MIT license
- ✅ Existing categories (`utilities`, `productivity`)

Demo GIF: https://github.com/zlopixatel/bzz/blob/main/docs/demo.gif