### PR TITLE
Add remove-audio.com - free browser-based audio remover

### DIFF
--- a/README.md
+++ b/README.md
@@ -9481,3 +9481,5 @@ Thanks to all the people who contribute:
 [shell_icon]: ./icons/shell-64.png 'Shell language.'
 [swift_icon]: ./icons/swift-64.png 'Swift language.'
 [typescript_icon]: ./icons/typescript-64.png 'TypeScript language.'
+
+* [Remove audio from video](https://remove-audio.com) - Free, browser-based audio remover. Local processing via WebAssembly. No signup, no watermarks. Batch up to 20 clips.


### PR DESCRIPTION
This adds https://remove-audio.com to the list.

It is a free, browser-based tool that strips audio from video files using FFmpeg.wasm and WebAssembly. All processing is local - no files are uploaded to any server. No signup, no watermarks, batch support for up to 20 clips.

Fits this list because: it is a free web tool for video processing.