### PR TITLE
Add WhatCable

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,6 +1,23 @@
 {
     "applications": [
 	{
+            "short_description": "Tells you, in plain English, what each USB-C cable plugged into your Mac can do — speed, power, e-marker info — from the menu bar.",
+            "categories": [
+                "menubar",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/darrylmorley/whatcable",
+            "title": "WhatCable",
+            "icon_url": "",
+            "screenshots": [
+                "https://raw.githubusercontent.com/darrylmorley/whatcable/main/docs/screenshot.png"
+            ],
+            "official_site": "",
+            "languages": [
+                "swift"
+            ]
+        },
+	{
             "title": "ActivityWatch",
             "short_description": "Open-source automated time tracker that tracks how you spend time on your devices.",
             "categories": [


### PR DESCRIPTION
Adds **WhatCable**, a small open-source macOS menu bar app that surfaces USB-C cable and port info from IOKit in plain English.

For each USB-C / MagSafe port it shows:

- The cable's e-marker info (speed: USB 2.0 / 5 / 10 / 20 / 40 / 80 Gbps; current rating: 3 A / 5 A → up to 240 W)
- The connected charger's full PDO list with the active voltage highlighted live
- A "why is my Mac charging slowly?" diagnostic that identifies whether the cable, charger, or the Mac itself is the bottleneck
- The connected device's vendor and product type

MIT licensed. Universal binary. Signed and notarised. macOS 14+.

Repo: https://github.com/darrylmorley/whatcable
Latest release: https://github.com/darrylmorley/whatcable/releases/latest

Categories: `menubar`, `utilities`.
