### PR TITLE
Add Whisky

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,24 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "Whisky",
+            "short_description": "Native SwiftUI Wine wrapper for macOS with D3DMetal/DXVK backends and built-in launcher compatibility (Steam, Epic, EA App, Battle.net). Active community fork of the archived whisky-app/whisky.",
+            "categories": [
+                "games",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/frankea/Whisky",
+            "icon_url": "https://raw.githubusercontent.com/frankea/Whisky/main/Whisky/Assets.xcassets/AppIcon.appiconset/512%402x.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/frankea/Whisky/main/images/config-screenshot.png",
+                "https://raw.githubusercontent.com/frankea/Whisky/main/images/new-bottle-screenshot.png"
+            ],
+            "official_site": "https://github.com/frankea/Whisky",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Project URL
https://github.com/frankea/Whisky

## Category
games, utilities

## Description
Native SwiftUI Wine wrapper for macOS with D3DMetal/DXVK backends and built-in launcher compatibility for Steam, Epic, EA App, and Battle.net. Apple Silicon, signed and notarized. Active community fork of the archived whisky-app/whisky.

## Why it should be included to `Awesome macOS open source applications` (optional)
GPL v3, written in Swift, actively maintained — latest release `app-v3.0.1` (May 2026). The original whisky-app/whisky was archived in April 2025; this fork continues development.

## Checklist
- [x] Edit applications.json instead of README.md
- [x] Only one project/change is in this pull request
- [x] Screenshots added
- [x] Has a commit from less than 2 years ago
- [x] Has a clear README in English
