### PR TITLE
Add qnote to Notes section

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -5058,6 +5058,24 @@
             ]
         },
         {
+            "short_description": "Minimal frameless notepad with local-only storage, no telemetry. Markdown live preview, real PDF export via Typst, OCR via Tesseract, automatic version history.",
+            "categories": [
+                "notes",
+                "editors"
+            ],
+            "repo_url": "https://github.com/Omibranch/qnote",
+            "title": "qnote",
+            "icon_url": "",
+            "screenshots": [
+                "https://i.ibb.co/SD9bzS9H/qnote-1dark.jpg"
+            ],
+            "official_site": "https://github.com/Omibranch/qnote",
+            "languages": [
+                "rust",
+                "typescript"
+            ]
+        },
+        {
             "short_description": "Plain-text file notepad and todo-list manager with markdown support and ownCloud / Nextcloud integration.",
             "categories": [
                 "markdown",


### PR DESCRIPTION
[qnote](https://github.com/Omibranch/qnote) is a minimal frameless notepad built with Tauri 2 (Rust + TypeScript), available for macOS, Linux, and Windows.

**Features:**
- Local-only storage, no telemetry, no cloud
- Markdown live preview with split editor
- Real PDF export via Typst
- OCR via Tesseract
- Automatic local version history
- Dark/light themes, custom fonts
- MIT license, available on AUR

Added to `applications.json` with categories `notes` and `editors`.