### PR TITLE
Add OpenQuack

### DIFF
--- a/README.md
+++ b/README.md
@@ -4694,6 +4694,10 @@ You can see in which language an app is written. Currently there are following l
   </p>
   </details>
 
+- [OpenQuack](https://github.com/larryxiao/openquack) - Local-only voice dictation for macOS — press a hotkey, speak, transcript pasted at cursor. WhisperKit on Apple Silicon, 99 Whisper languages, no telemetry.
+
+  **Languages:** <img src='./icons/swift-64.png' alt='Swift icon' title='Swift' height='16'/> Swift 
+
 - [Pareto Security](https://github.com/paretoSecurity/pareto-mac/) - A MenuBar app to automatically audit your Mac for basic security hygiene.
 
   **Languages:** <img src='./icons/swift-64.png' alt='Swift icon' title='Swift' height='16'/> Swift 


### PR DESCRIPTION
Adds **OpenQuack** — a privacy-first local voice dictation menu bar app for macOS — to `applications.json`.

- Repo: https://github.com/larryxiao/openquack
- License: MIT
- Languages: Swift
- Categories: `utilities`, `menubar`
- Icon: 512×512 PNG hosted in the repo at `docs/images/icon-512.png`
- Screenshot: README banner

Description: privacy-first local voice dictation — push a hotkey, speak, the transcript is pasted at the cursor. Runs WhisperKit on Apple Silicon, supports 99 Whisper languages, all on-device (no cloud, no signup, no telemetry). Edited `applications.json` per the contribution guidelines (not the auto-generated README).

Thanks for maintaining the list!