### PR TITLE
Add new-markdown

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,24 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "new-markdown",
+            "short_description": "One-click \"New Markdown File\" button for the macOS Finder toolbar. Creates a blank .md in the current folder and enters rename mode.",
+            "categories": [
+                "finder",
+                "markdown"
+            ],
+            "repo_url": "https://github.com/Squarelight-ai/new-markdown",
+            "icon_url": "https://raw.githubusercontent.com/Squarelight-ai/new-markdown/main/assets/icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/Squarelight-ai/new-markdown/main/assets/screenshot.png"
+            ],
+            "official_site": "https://github.com/Squarelight-ai/new-markdown",
+            "languages": [
+                "applescript",
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Adding [**new-markdown**](https://github.com/Squarelight-ai/new-markdown) — a one-click "New Markdown File" button for the macOS Finder toolbar.

## What it does
- Click a Finder toolbar icon → creates a blank `.md` file in the front Finder window's folder
- Immediately enters rename mode so users can name and start typing
- No menu bar item, no dock icon, no background process

## Why it fits this list
- Open source (Apache 2.0)
- Native macOS app (AppleScript bundle, no external runtime)
- Active maintenance (initial public release v1.0.0)
- Categories: `finder` + `markdown` (double-tagged for discoverability)
- Tested on macOS 13+ through macOS 26 (Tahoe)

## Preview
![Screenshot](https://raw.githubusercontent.com/Squarelight-ai/new-markdown/main/assets/screenshot.png)

## Compliance with contribution guidelines
- ✅ Individual PR for a single suggestion
- ✅ Edits `applications.json` (not `README.md`)
- ✅ Follows the canonical entry schema
- ✅ Short, descriptive `short_description` ending in a period
- ✅ Categories are pre-existing IDs from `categories.json`
- ✅ Recent commits, README in English, has license