### PR TITLE
Add Live Translator

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,6 +1,21 @@
 {
     "applications": [
 	{
+            "title": "Live Translator",
+            "short_description": "Real-time on-screen translation of any system audio (YouTube, podcasts, meetings) using OpenAI or Google Gemini.",
+            "categories": [
+                "Utilities",
+                "Menubar"
+            ],
+            "repo_url": "https://github.com/umutcetinkaya/live-translator",
+            "icon_url": "https://raw.githubusercontent.com/umutcetinkaya/live-translator/main/assets/icon.png",
+            "screenshots": [],
+            "official_site": "https://github.com/umutcetinkaya/live-translator",
+            "languages": [
+                "Python"
+            ]
+        },
+	{
             "title": "ActivityWatch",
             "short_description": "Open-source automated time tracker that tracks how you spend time on your devices.",
             "categories": [


### PR DESCRIPTION
Adds Live Translator — an open-source macOS menu-bar app for real-time on-screen translation of any system audio (YouTube, podcasts, meetings) using OpenAI or Google Gemini. On-device speech recognition by default; optional realtime mode. macOS 13+.