### PR TITLE
Add Clave to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -1325,7 +1325,7 @@ You can see in which language an app is written. Currently there are following l
   </p>
   </details>
 
-### 👨‍💻 Development (16)
+### 👨‍💻 Development (17)
 - [Apache Netbeans](https://github.com/apache/netbeans) - Apache NetBeans is an IDE, Tooling Platform and Application Framework suitable for development in Java, JavaScript, PHP, HTML5, CSS, and more.
 
   **Languages:** <img src='./icons/java-64.png' alt='Java icon' title='Java' height='16'/> Java 
@@ -1357,6 +1357,12 @@ You can see in which language an app is written. Currently there are following l
 
   </p>
   </details>
+
+- [Clave](https://github.com/codika-io/clave) - macOS app for managing multiple Claude Code sessions in parallel, with split/grid layouts, session groups, SSH remote sessions, a git panel, and usage analytics. Local-first.
+
+  **Languages:** <img src='./icons/typescript-64.png' alt='TypeScript icon' title='TypeScript' height='16'/> TypeScript 
+
+  **Website:** [https://github.com/codika-io/clave](https://github.com/codika-io/clave)
 
 - [Clipboard](https://github.com/Slackadays/Clipboard) - An easy-to-use clipboard manager with time saving features that work across all terminals.
 


### PR DESCRIPTION
Adds [Clave](https://github.com/codika-io/clave) to the **Development** section (alphabetical, between Brackets and Clipboard; section count bumped 16 → 17).

Clave is an open-source (MIT) macOS app for managing multiple Claude Code sessions in parallel — split/grid layouts, session groups, SSH remote sessions, a git panel, and usage analytics. Built with TypeScript/Electron. Entry follows the Languages/Website format used in the section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)