### PR TITLE
Add Claudia: OSS menu bar dev service monitor

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -36,7 +36,7 @@
         },
 
 	{
-            "short_description": "Menu bar app that monitors Docker, Supabase, and your local dev server, and lets you start them with one click when they're down.",
+            "short_description": "Menu bar app that monitors any local dev service (Docker, Postgres, Supabase, Redis, Next.js, Vite, and 12+ other presets, or your own) and starts them with one click when they're down.",
             "categories": [
                 "development",
                 "menubar"
@@ -44,7 +44,11 @@
             "repo_url": "https://github.com/sudyke/Claudia",
             "title": "Claudia",
             "icon_url": "https://raw.githubusercontent.com/sudyke/Claudia/main/Claudia/Assets.xcassets/ClaudeCode.imageset/claudecode-color.svg",
-            "screenshots": [],
+            "screenshots": [
+                "https://raw.githubusercontent.com/sudyke/Claudia/main/docs/screenshots/popover.png",
+                "https://raw.githubusercontent.com/sudyke/Claudia/main/docs/screenshots/settings-services.png",
+                "https://raw.githubusercontent.com/sudyke/Claudia/main/docs/screenshots/add-service.png"
+            ],
             "official_site": "https://github.com/sudyke/Claudia",
             "languages": [
                 "swift"

--- a/applications.json
+++ b/applications.json
@@ -36,6 +36,22 @@
         },
 
 	{
+            "short_description": "Menu bar app that monitors Docker, Supabase, and your local dev server, and lets you start them with one click when they're down.",
+            "categories": [
+                "development",
+                "menubar"
+            ],
+            "repo_url": "https://github.com/sudyke/Claudia",
+            "title": "Claudia",
+            "icon_url": "https://raw.githubusercontent.com/sudyke/Claudia/main/Claudia/Assets.xcassets/ClaudeCode.imageset/claudecode-color.svg",
+            "screenshots": [],
+            "official_site": "https://github.com/sudyke/Claudia",
+            "languages": [
+                "swift"
+            ]
+        },
+
+	{
             "title": "VPN Bypass",
             "short_description": "Route specific domains and services around your corporate VPN while keeping the rest of your traffic protected.",
             "categories": [


### PR DESCRIPTION
Adds [Claudia](https://github.com/sudyke/Claudia) — a macOS menu bar app that monitors any local dev service and starts them with one click when they're down.

17+ built-in presets across Containers (Docker, OrbStack, Colima), Databases (Postgres, MySQL, Supabase, Redis, MongoDB), Dev Servers (Next.js, Vite, Astro, Storybook, Rails, Django), and Tools (Mailpit, LocalStack, ngrok). Three check types (HTTP / TCP socket / shell exit code) and three start action types (open app / Terminal command / one-shot shell) cover essentially any local stack. Custom services for anything the presets don't.

- Categories: `development`, `menubar`
- License: MIT
- Written in Swift 6 (strict concurrency), SwiftUI + AppKit menu bar
- Free, open source, first-party Apple frameworks only — no SPM dependencies
- Available via Homebrew: `brew install --cask sudyke/tap/claudia-monitor`

Screenshots and full feature list in the [README](https://github.com/sudyke/Claudia).

Checklist (per `CONTRIBUTING.md`):
- [x] Edited `applications.json`, not `README.md`
- [x] Description is short and ends with a period
- [x] Categories exist in `categories.json`
- [x] Individual PR for a single addition