### PR TITLE
Add Terminal Workspace

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,24 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "Terminal Workspace",
+            "short_description": "Multi-project terminal workspace for managing many developer terminals from one macOS desktop app.",
+            "categories": [
+                "terminal",
+                "developer"
+            ],
+            "repo_url": "https://github.com/EvanAI0331/terminal-workspace",
+            "icon_url": "https://raw.githubusercontent.com/EvanAI0331/terminal-workspace/main/assets/TerminalTopology.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/EvanAI0331/terminal-workspace/main/site/terminal-workspace-1440.png"
+            ],
+            "official_site": "https://evanai0331.github.io/terminal-workspace/",
+            "languages": [
+                "typescript",
+                "javascript"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Adds Terminal Workspace, an open-source macOS desktop app for managing multiple project terminals from one workspace.

Notes:
- Category: terminal / developer
- Repository: https://github.com/EvanAI0331/terminal-workspace
- Official site: https://evanai0331.github.io/terminal-workspace/

I kept the change scoped to applications.json as requested in CONTRIBUTING.md.