### PR TITLE
Add Mac Clean

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -6538,6 +6538,23 @@
             ]
         },
         {
+            "short_description": "Free, open-source CleanMyMac alternative built with Swift 6 and SwiftUI. Smart Scan, 16 junk categories, malware scanner, uninstaller with leftover detection, Space Lens treemap, duplicates, and a live menu bar monitor.",
+            "categories": [
+                "system",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/iliyami/MacClean",
+            "title": "Mac Clean",
+            "icon_url": "https://raw.githubusercontent.com/iliyami/MacClean/main/assets/app_icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/iliyami/MacClean/main/assets/demo.png"
+            ],
+            "official_site": "https://github.com/iliyami/MacClean",
+            "languages": [
+                "swift"
+            ]
+        },
+        {
             "short_description": "Simple network activity monitor for macOS. ",
             "categories": [
                 "system"


### PR DESCRIPTION
Adding [Mac Clean](https://github.com/iliyami/MacClean) — a new open-source CleanMyMac alternative.

### Checklist
- [x] Edited `applications.json` (not README.md)
- [x] Single PR for single suggestion
- [x] Used the required JSON format
- [x] Description ends with a period
- [x] No duplicates (searched before adding)

### About the project
Free, open-source (BSD-3 license) Mac cleaner / optimizer / malware scanner. Swift 6, SwiftUI, macOS 14+.

**Categories used:** `system`, `utilities` (both exist in categories.json)

**Features:**
- Smart Scan (one-click cleanup across 13 modules)
- System Junk (16 scan categories — caches, logs, language files, broken prefs, Xcode junk, iOS backups, universal binaries, etc.)
- Malware scanner with signature matching (3 scan depths)
- Privacy cleanup (Safari/Chrome/Firefox)
- Uninstaller with 10-level matching engine for leftover detection
- Space Lens (squarified treemap)
- Duplicates (progressive size → partial SHA-256 → full hash)
- Menu bar monitor (CPU/RAM/Disk/Battery/Network)
- XPC privileged helper for maintenance tasks

No telemetry. No subscription. 56 tests passing on each push.

Thanks for maintaining this list!