### PR TITLE
Add StayUp (System)

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -6522,6 +6522,20 @@
             ]
         },
         {
+            "short_description": "Keeps your Mac awake on battery with the lid closed — the Apple Silicon clamshell case that caffeinate-based blockers can't cover.",
+            "categories": [
+                "system"
+            ],
+            "repo_url": "https://github.com/NongKnot/StayUp",
+            "title": "StayUp",
+            "icon_url": "",
+            "screenshots": [],
+            "official_site": "https://getstayup.app",
+            "languages": [
+                "swift"
+            ]
+        },
+        {
             "short_description": "Small utility app for macOS that makes sure you know about all the latest updates to the apps you use. ",
             "categories": [
                 "system"


### PR DESCRIPTION
Adding **StayUp** to the **System** category, alongside KeepingYouAwake.

- **What it is:** an open-source (MIT) menu-bar app that keeps a Mac awake on **battery with the lid closed** — the Apple Silicon clamshell + battery case that `caffeinate`-based blockers can't cover.
- **Repo:** https://github.com/NongKnot/StayUp
- **Site:** https://getstayup.app
- Free, no telemetry, written in Swift.

Edited `applications.json` (not README) per CONTRIBUTING; description ends with a period, no trailing whitespace. Individual PR for this one app.