### PR TITLE
Add Markup to Markdown editors

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -3060,6 +3060,21 @@
             ]
         },
         {
+            "short_description": "Reader-first, native macOS Markdown editor: renders notes like a web page and edits on demand, with a vault, backlinks, graph view and full-text search.",
+            "categories": [
+                "markdown"
+            ],
+            "repo_url": "https://github.com/oratis/Markup",
+            "title": "Markup",
+            "icon_url": "",
+            "screenshots": [],
+            "official_site": "",
+            "languages": [
+                "rust",
+                "typescript"
+            ]
+        },
+        {
             "short_description": "Realtime preview markdown editor for macOS Windows and Linux. ",
             "categories": [
                 "markdown"


### PR DESCRIPTION
## Project URL
https://github.com/oratis/Markup

## Category
markdown

## Description
Markup is a free, open-source (MIT), native macOS Markdown editor built on Tauri 2 (Rust + system WebView). It is reader-first: it renders your Markdown like a clean web page by default and you edit on demand (WYSIWYG via Milkdown, or raw source). It includes a real vault with wikilinks/backlinks, a graph view, and full-text search powered by Tantivy. Idle RAM is ~88 MB.

## Checklist
- [x] Edit applications.json instead of README.md.
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English