### PR TITLE
Add Stargazer Bar

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1897,6 +1897,23 @@
             ]
         },
         {
+            "short_description": "Track one public GitHub repo's stars and release downloads from the menu bar.",
+            "categories": [
+                "development",
+                "menubar"
+            ],
+            "repo_url": "https://github.com/jazzyalex/stargazer-bar",
+            "title": "Stargazer Bar",
+            "icon_url": "https://raw.githubusercontent.com/jazzyalex/stargazer-bar/main/GHMenuStars/Assets.xcassets/AppIcon.appiconset/icon_1024.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/jazzyalex/stargazer-bar/main/docs/assets/hero-stage.png"
+            ],
+            "official_site": "https://jazzyalex.github.io/stargazer-bar/",
+            "languages": [
+                "swift"
+            ]
+        },
+        {
             "short_description": "macOS status bar application for tracking code review process within the team. ",
             "categories": [
                 "git"


### PR DESCRIPTION
Adds Stargazer Bar, an open-source native macOS menu bar app for tracking one public GitHub repo's stars and release downloads.

It is built with Swift, has a recent release, includes an English README, and is distributed via GitHub Releases and Homebrew.