### PR TITLE
Add quokka: inspect and clean an iPhone from the macOS terminal

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,6 +1,22 @@
 {
     "applications": [
 	{
+            "title": "quokka",
+            "short_description": "Inspect and clean a USB-connected iPhone from the macOS terminal: storage, apps, media, syslog. No jailbreak.",
+            "categories": [
+                "ios--macos",
+                "terminal",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/dutradotdev/quokka",
+            "icon_url": "",
+            "screenshots": [],
+            "official_site": "",
+            "languages": [
+                "rust"
+            ]
+        },
+	{
             "title": "ActivityWatch",
             "short_description": "Open-source automated time tracker that tracks how you spend time on your devices.",
             "categories": [


### PR DESCRIPTION
Adds quokka to applications.json (categories: ios--macos, terminal, utilities), per the contributing guidelines (edit JSON, not README).

Repo: https://github.com/dutradotdev/quokka
An open-source Rust CLI/TUI that inspects and cleans a USB-connected iPhone from the macOS terminal. No jailbreak.
