### PR TITLE
Add usage – macOS menu bar app for Claude Code + Codex quota

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1081,6 +1081,23 @@
             ]
         },
         {
+            "title": "usage",
+            "short_description": "macOS menu bar app that pins Claude Code and Codex quota to the screen by reading local session files. Includes Progress Concierge for automatic session resume.",
+            "categories": [
+                "menubar",
+                "development"
+            ],
+            "repo_url": "https://github.com/aqua5230/usage",
+            "icon_url": "https://aqua5230.github.io/usage/avatar.png",
+            "screenshots": [
+                "https://aqua5230.github.io/usage/hero.png"
+            ],
+            "official_site": "https://aqua5230.github.io/usage/",
+            "languages": [
+                "python"
+            ]
+        },
+        {
             "short_description": "Tiny multiprocessing utility for file backups.",
             "categories": [
                 "backup"

--- a/applications.json
+++ b/applications.json
@@ -1082,7 +1082,7 @@
         },
         {
             "title": "usage",
-            "short_description": "macOS menu bar app that pins Claude Code and Codex quota to the screen by reading local session files. Includes Progress Concierge for automatic session resume.",
+            "short_description": "macOS menu bar and Windows tray app that pins Claude Code, Codex, and Antigravity quota to the screen. Claude Code and Codex are read from local session files. Includes Progress Concierge for automatic session resume.",
             "categories": [
                 "menubar",
                 "development"


### PR DESCRIPTION
## New application: usage

**usage** is an open-source macOS menu bar app that reads Claude Code's local status hook and Codex session logs to pin quota and burn rate to the screen — no API calls, no authentication required.

### Details

| Field | Value |
|---|---|
| Repo | https://github.com/aqua5230/usage |
| License | AGPL-3.0 |
| Language | Python |
| Categories | `menubar`, `development` |
| Official site | https://aqua5230.github.io/usage/ |
| Stars | 160+ |
| Last release | v0.13.0 (2026-05-31) |

### What it does

- Pins Claude Code 5-hour and 7-day quota percentages to the menu bar
- Also tracks Codex quota from its native session JSONL logs
- Shows per-project token breakdowns and cost estimates in a popover
- Includes **Progress Concierge**: an opt-in SessionStart hook that auto-injects the last session's context into new conversations
- Installable via Homebrew

Happy to adjust the entry to fit the list's conventions.