### PR TITLE
Add Sleepless

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,6 +1,17 @@
 {
     "applications": [
 	{
+            "short_description": "Keep your MacBook awake with the lid closed, on battery, with no external display, with a battery-floor auto-off.",
+            "categories": [
+                "menubar"
+            ],
+            "repo_url": "https://github.com/Aboudjem/Sleepless",
+            "title": "Sleepless",
+            "languages": [
+                "swift"
+            ]
+        },
+	{
             "title": "ActivityWatch",
             "short_description": "Open-source automated time tracker that tracks how you spend time on your devices.",
             "categories": [
@@ -166,7 +177,7 @@
         {
             "short_description": "Fun Tic Tac Toe game equipped with multiplayer (local and online) and leveled single player available on the App Store.",
             "categories": [
-                "games",
+                "games"
             ],
             "repo_url": "https://github.com/Aries-Sciences-LLC/Tic-Tac-Toe",
             "title": "Amazing Tic Tac Toe",
@@ -184,7 +195,7 @@
         {
             "short_description": "Simple and elegant menubar weather app on the App Store.",
             "categories": [
-                "menubar",
+                "menubar"
             ],
             "repo_url": "https://github.com/Aries-Sciences-LLC/Quick-Weather",
             "title": "Quick Weather",


### PR DESCRIPTION
Adds **Sleepless** to `applications.json` under the `menubar` category.

Sleepless is an MIT-licensed, native Swift/AppKit menu-bar app that keeps a MacBook awake with the lid closed, on battery, with no external display (via `pmset disablesleep`), and automatically turns off at a configurable battery floor. It fits right alongside the other Menubar utilities.

- Repo: https://github.com/Aboudjem/Sleepless
- License: MIT · Native Swift/AppKit · recent commits

Per CONTRIBUTING I edited `applications.json` (not the generated README), used the JSON object format, ended the description with a period, and confirmed it isn't already listed. I also removed two pre-existing trailing commas in the file so it now parses as strict JSON (the README generator decodes it with Swift's `JSONDecoder`). Validated locally with `jq . applications.json`.