### PR TITLE
Add Skilly — voice-first AI tutor for macOS

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,6 +1,21 @@
 {
     "applications": [
 	{
+            "title": "Skilly",
+            "short_description": "Voice-first AI tutor that watches your screen and points at on-screen UI elements to teach creative software like Blender, Figma, and Premiere.",
+            "categories": [
+                "productivity",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/tryskilly/skilly",
+            "icon_url": "https://raw.githubusercontent.com/tryskilly/skilly/main/leanring-buddy/Assets.xcassets/AppIcon.appiconset/1024-mac.png",
+            "screenshots": [],
+            "official_site": "https://tryskilly.app",
+            "languages": [
+                "swift"
+            ]
+        },
+	{
             "title": "ActivityWatch",
             "short_description": "Open-source automated time tracker that tracks how you spend time on your devices.",
             "categories": [


### PR DESCRIPTION
Adds **Skilly** to `applications.json` (productivity, utilities).

Skilly is an open-source (Apache-2.0) voice-first AI tutor for macOS. It watches your screen and points at on-screen UI elements to teach creative software like Blender, Figma, and Premiere.

- Repo: https://github.com/tryskilly/skilly
- Site: https://tryskilly.app
- Language: Swift

Inserted as a JSON entry following the existing schema (icon is the repo's 1024px AppIcon).