### PR TITLE
Add Dusty

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,23 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "Dusty",
+            "short_description": "Menu bar disk cleaner that only deletes from a fixed allowlist and shows every path and size before removing anything.",
+            "categories": [
+                "utilities",
+                "menubar"
+            ],
+            "repo_url": "https://github.com/yagcioglutoprak/dusty",
+            "icon_url": "https://raw.githubusercontent.com/yagcioglutoprak/dusty/main/Dusty/Dusty/Assets.xcassets/AppIcon.appiconset/icon_512.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/yagcioglutoprak/dusty/main/docs/screenshots/panel.png"
+            ],
+            "official_site": "https://toprak.sh/dusty",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Adds Dusty, a free and open-source (MIT) macOS menu bar disk cleaner.

It reclaims space from caches, logs, and developer junk, and the design goal is that it can only ever delete from a fixed allowlist: it shows every path and its size before removing anything, supports a dry run, can move to Trash with undo, and writes a deletion log. The deletion engine is a separate, unit-tested Swift package. Signed and notarized, installable via Homebrew.

Repo: https://github.com/yagcioglutoprak/dusty
Site: https://toprak.sh/dusty

Followed the contributing guide: edited applications.json (not the README), individual PR for this one app, description ends with a period, icon and screenshot URLs included.