### PR TITLE
Add Fader - menu bar volume mixer

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,23 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "Fader",
+            "short_description": "Menu bar volume mixer with per-app volume, one-click audio output switching, and Bluetooth headphone control.",
+            "categories": [
+                "audio",
+                "menubar"
+            ],
+            "repo_url": "https://github.com/pantafive/fader",
+            "icon_url": "https://raw.githubusercontent.com/pantafive/fader/main/site/icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/pantafive/fader/main/docs/screenshot.png"
+            ],
+            "official_site": "https://fader.pantafive.dev",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Project URL
https://github.com/pantafive/fader

## Category
audio, menubar

## Description
Fader is a menu bar volume mixer for macOS. Every app that plays sound gets its own volume fader and mute toggle, built on Core Audio process taps, so there is no kernel extension and no virtual audio driver. Output devices switch in one click, paired Bluetooth headphones connect straight from the popover, and a microphone tab switches the default input and sets input gain. MIT-licensed, written in Swift, signed and notarized, zero network code.

## Why it should be included to `Awesome macOS open source applications ` (optional)
Per-app volume on macOS is otherwise covered by paid apps (SoundSource, Sound Control) or projects that require a virtual audio driver (Background Music). Fader does it driverless on the modern API, free and open source.

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
