### PR TITLE
Add LanGuard (utilities/menubar)

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,21 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "LanGuard",
+            "short_description": "Wi-Fi off when wired LAN active, back on when unplugged. Edge-based, wake-aware, no admin.",
+            "categories": [
+                "utilities",
+                "menubar"
+            ],
+            "repo_url": "https://github.com/roypadina/LanGuard",
+            "icon_url": "",
+            "screenshots": [],
+            "official_site": "https://github.com/roypadina/LanGuard",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Adds **LanGuard** to applications.json under `utilities` + `menubar` (edited applications.json per CONTRIBUTING, not README).

LanGuard is a free, open-source (MIT) macOS menu-bar app that turns Wi-Fi off when a wired LAN link is active and back on when unplugged — edge-based, wake-aware, no admin rights.

Repo: https://github.com/roypadina/LanGuard