### PR TITLE
Add Mole Widget (Menubar)

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,23 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "short_description": "Lightweight macOS desktop system monitor with live CPU, memory, disk, network, battery, and process metrics, managed from the menu bar.",
+            "categories": [
+                "menubar",
+                "system"
+            ],
+            "repo_url": "https://github.com/bsnkhua/mole-widget",
+            "title": "Mole Widget",
+            "icon_url": "",
+            "screenshots": [
+               "https://raw.githubusercontent.com/bsnkhua/mole-widget/main/assets/widget.webp"
+            ],
+            "official_site": "https://github.com/bsnkhua/mole-widget",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Project URL
https://github.com/bsnkhua/mole-widget

## Category
menubar, system

## Description
Mole Widget is a lightweight, free, open-source (MIT) macOS system monitor that displays live CPU, memory, disk, network, battery, and process metrics in a resizable desktop widget managed from the menu bar (launch at login, settings, update notifications). Built with Swift + SwiftUI. Install: `brew install bsnkhua/tap/mole-widget`.

## Why it should be included to `Awesome macOS open source applications ` (optional)
Actively maintained, MIT-licensed, native Swift/SwiftUI app with a clear English README and Homebrew installation. Recently accepted to jaywcjlove/awesome-mac.

## Checklist
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English