### PR TITLE
Add Agent CLI Menu

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,6 +1,23 @@
 {
     "applications": [
 	{
+            "title": "Agent CLI Menu",
+            "short_description": "TUI and menu-bar launcher to start or resume Claude Code and Codex coding-agent sessions, with full-transcript fuzzy search of past sessions.",
+            "categories": [
+                "development",
+                "menubar",
+                "terminal"
+            ],
+            "repo_url": "https://github.com/roypadina/AgentCliMenu",
+            "icon_url": "",
+            "screenshots": [],
+            "official_site": "https://github.com/roypadina/AgentCliMenu",
+            "languages": [
+                "typescript",
+                "swift"
+            ]
+        },
+	{
             "title": "ActivityWatch",
             "short_description": "Open-source automated time tracker that tracks how you spend time on your devices.",
             "categories": [


### PR DESCRIPTION
Adds **Agent CLI Menu** to `applications.json` (categories: development, menubar, terminal; languages: typescript, swift).

A free, open-source macOS TUI **and** menu-bar app to start or resume Claude Code / Codex coding-agent sessions: a frecency-sorted project launcher, and full-transcript fuzzy search across every past session with an inline transcript peek. MIT, `brew install --cask roypadina/tap/agentclimenu`.

- Edited `applications.json` only (README is generated)
- Validated JSON parses
- Disclosure: I'm the author