### PR TITLE
Add Featherbar

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -9464,6 +9464,24 @@
             ]
         },
         {
+            "short_description": "Featherweight menu bar system monitor showing CPU, RAM, power, and temperature in two color-coded lines.",
+            "categories": [
+                "system",
+                "utilities",
+                "menubar"
+            ],
+            "repo_url": "https://github.com/nim444/featherbar",
+            "title": "Featherbar",
+            "icon_url": "",
+            "screenshots": [
+                "https://raw.githubusercontent.com/nim444/featherbar/main/assets/menubar.png"
+            ],
+            "official_site": "https://crates.io/crates/featherbar",
+            "languages": [
+                "rust"
+            ]
+        },
+        {
             "repo_url": "https://github.com/87kangsw/ThenGenerator",
             "official_site": "",
             "title": "ThenGenerator",


### PR DESCRIPTION
## Featherbar

[Featherbar](https://github.com/nim444/featherbar) is an open-source (Apache-2.0) featherweight macOS menu-bar system monitor written in Rust. It shows CPU, RAM, power draw, and temperature in two color-coded menu bar lines, with zero background threads and flat memory usage (~20MB).

- Added to `applications.json` per the contribution guidelines (categories: system, utilities, menubar; language: rust)
- Actively maintained, published on [crates.io](https://crates.io/crates/featherbar) (v0.2.1)
- English README with screenshot, Apache-2.0 licensed