### PR TITLE
Add Vuvuzela

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,24 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "Vuvuzela",
+            "short_description": "FIFA World Cup 2026 desktop widget with live scores, group standings, and the knockout bracket.",
+            "categories": [
+                "menubar"
+            ],
+            "repo_url": "https://github.com/bsnkhua/vuvuzela",
+            "icon_url": "https://raw.githubusercontent.com/bsnkhua/vuvuzela/main/assets/icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/bsnkhua/vuvuzela/main/assets/screenshot-groups.png",
+                "https://raw.githubusercontent.com/bsnkhua/vuvuzela/main/assets/screenshot-matches.jpeg",
+                "https://raw.githubusercontent.com/bsnkhua/vuvuzela/main/assets/screenshot-bracket.jpeg"
+            ],
+            "official_site": "https://github.com/bsnkhua/vuvuzela",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Project URL
https://github.com/bsnkhua/vuvuzela

## Category
menubar

## Description
Vuvuzela is a desktop widget and menu bar app for following the FIFA World Cup 2026: live group standings, a day-by-day match schedule, and the knockout bracket. In-play matches are highlighted with the live score and match minute, favourite teams get goal / kick-off / half-time / full-time notifications with sound, and the app auto-updates via Sparkle. Open source, written in Swift.

## Why it should be included to `Awesome macOS open source applications ` (optional)
Open-source (MIT), actively maintained Swift menu bar app with a clear English README and screenshots.

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
