### PR TITLE
Add WindowCycle

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -16,6 +16,24 @@
                 "typescript"
             ]
         },
+        {
+            "short_description": "A focused macOS current-app window switcher with a visible panel.",
+            "categories": [
+                "window-management",
+                "keyboard",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/WhiteMinds/window-cycle",
+            "title": "WindowCycle",
+            "icon_url": "https://raw.githubusercontent.com/WhiteMinds/window-cycle/main/Resources/AppIcon.icns",
+            "screenshots": [
+                "https://github.com/user-attachments/assets/ef651ee8-5190-400a-adba-b8e856068736"
+            ],
+            "official_site": "https://github.com/WhiteMinds/window-cycle",
+            "languages": [
+                "swift"
+            ]
+        },
 	{
             "short_description": "Clipboard history manager for macOS with terminal-style navigation, image previews, and cursor-following popup.",
             "categories": [


### PR DESCRIPTION
## Project URL
https://github.com/WhiteMinds/window-cycle

## Category
window-management, keyboard, utilities

## Description
WindowCycle is a lightweight native macOS prototype for switching between windows of the current frontmost app. It uses ⌘+` and ⌘+Shift+` to cycle forward/backward, with a compact visible switcher panel and current-app-only behavior.

## Why it should be included to `Awesome macOS open source applications ` (optional)
It is an open-source MIT macOS utility focused on current-app window switching, useful for people who work with many windows in the same IDE, browser, Terminal, Finder, or similar app.

## Checklist
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English
