### PR TITLE
Add Cluxo (cursor highlighter for screencasts)

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,23 @@
             "languages": [
                 "swift"
             ]
+        },
+	{
+            "title": "Cluxo",
+            "short_description": "Menu bar app that highlights your mouse cursor for screencasts, presentations, and pair programming.",
+            "categories": [
+                "menubar",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/kykim79/Cluxo",
+            "icon_url": "https://raw.githubusercontent.com/kykim79/Cluxo/main/Sources/Cluxo/Assets.xcassets/AppIcon.appiconset/icon_512x512.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/kykim79/Cluxo/main/docs/screenshots/01-hero-en.gif"
+            ],
+            "official_site": "https://github.com/kykim79/Cluxo",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Adds **Cluxo**, an open-source macOS menu bar app that highlights the mouse cursor for screencasts, presentations, and pair programming (cursor ring, spotlight, magnifier, keystroke overlay, radial menu, drawing mode).

- Repo: https://github.com/kykim79/Cluxo
- License: MIT
- Language: Swift / SwiftUI, macOS 13+
- Install: `brew install --cask kykim79/tap/cluxo`

Edited `applications.json` per CONTRIBUTING. Categories: menubar, utilities.