### PR TITLE
Add Offsend

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,26 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "Offsend",
+            "short_description": "Local-first menu bar app that prepares projects, files, and clipboard text for AI tools by detecting and masking sensitive data.",
+            "categories": [
+                "menubar",
+                "security",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/Offsend/Offsend",
+            "icon_url": "https://raw.githubusercontent.com/Offsend/Offsend/main/App/Resources/Assets.xcassets/AppIcon.appiconset/256.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/Offsend/Offsend/main/assets/clipboard.png",
+                "https://raw.githubusercontent.com/Offsend/Offsend/main/assets/docs.png",
+                "https://raw.githubusercontent.com/Offsend/Offsend/main/assets/projects.png"
+            ],
+            "official_site": "https://offsend.io",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/Offsend/Offsend

## Category
security, utilities, menubar

## Description
Offsend is a local-first macOS menu bar app that prepares projects, files, and clipboard text before you share them with AI tools like ChatGPT, Claude, or Cursor. It detects and masks sensitive data — API keys, tokens, emails, internal paths — entirely on your Mac, with no cloud scanning or account required. You can audit project folders, sanitize files, and use Safe Paste (⌘⇧V) to paste cleaned text into any app. Open source, Swift, Apache 2.0
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
The catalog has no app built for the workflow of preparing content before sharing it with AI tools. Offsend detects and masks sensitive data — API keys, tokens, internal paths — in project folders, files, and clipboard text, entirely on your Mac. It helps developers avoid leaking secrets when copying code and logs into ChatGPT, Claude, or Cursor. A relevant open-source utility for the menubar, security, and utilities categories.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English
