### PR TITLE
Add Cate to IDE section

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,6 +1,20 @@
 {
     "applications": [
 	{
+            "short_description": "IDE built on an infinite zoomable canvas. Editor, terminal, browser, and AI agent panels float in a spatial workspace instead of tabs.",
+            "categories": [
+                "ide"
+            ],
+            "repo_url": "https://github.com/0-AI-UG/cate",
+            "title": "Cate",
+            "icon_url": "",
+            "screenshots": [],
+            "official_site": "https://cate.cero-ai.com",
+            "languages": [
+                "typescript"
+            ]
+        },
+	{
             "title": "ActivityWatch",
             "short_description": "Open-source automated time tracker that tracks how you spend time on your devices.",
             "categories": [


### PR DESCRIPTION
Adds Cate, an open source IDE (MIT) built on an infinite zoomable canvas. You arrange Monaco editors, xterm.js terminals, embedded browsers, and AI agent panels in freeform space, and panels can dock into tabs or detach into separate windows. Electron + React + TypeScript, actively developed, macOS builds available.
