### PR TITLE
Add Lurar (menu-bar parametric EQ for headphones)

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,24 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "Lurar",
+            "short_description": "Menu-bar parametric EQ for headphones. Loads the AutoEq catalog and applies it system-wide via Apple's Core Audio Process Tap — no virtual audio driver.",
+            "categories": [
+                "audio",
+                "menubar"
+            ],
+            "repo_url": "https://github.com/lsjoberg/lurar",
+            "icon_url": "https://raw.githubusercontent.com/lsjoberg/lurar/main/docs/branding/app-icon.svg",
+            "screenshots": [
+                "https://raw.githubusercontent.com/lsjoberg/lurar/main/docs/screenshots/editor.png",
+                "https://raw.githubusercontent.com/lsjoberg/lurar/main/docs/screenshots/menu-bar.png"
+            ],
+            "official_site": "https://lurar.app/",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Project URL
https://github.com/lsjoberg/lurar

## Category
audio, menubar

## Description
I built Lurar, a free, open-source (MIT) macOS menu-bar parametric EQ for headphones. It loads the AutoEq catalog and applies the correction system-wide using Apple's Core Audio Process Tap API (macOS 14.2+) — so unlike most macOS EQ tools it needs no BlackHole / virtual audio driver. Native Swift, signed + notarized, Apple Silicon and Intel.

- Site: https://lurar.app/
- Source: https://github.com/lsjoberg/lurar

## Why it should be included to `Awesome macOS open source applications` (optional)
It fills a gap in the audio category: system-wide headphone EQ without installing a virtual audio driver. MIT licensed, actively developed, no account or telemetry.

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English