### PR TITLE
Add Headroom — Claude Code usage meter in the menu bar

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -7501,6 +7501,23 @@
             ]
         },
         {
+            "short_description": "Claude Code usage in the menu bar — live 5-hour session and 7-day week percentages, color-coded as a limit approaches.",
+            "categories": [
+                "menubar",
+                "development"
+            ],
+            "repo_url": "https://github.com/patwalls/headroom",
+            "title": "Headroom",
+            "icon_url": "",
+            "screenshots": [
+                "https://headroom.walls.sh/dropdown.png"
+            ],
+            "official_site": "https://headroom.walls.sh",
+            "languages": [
+                "swift"
+            ]
+        },
+        {
             "short_description": "HandBrake is a video transcoder available for Linux, Mac, and Windows. ",
             "categories": [
                 "video"


### PR DESCRIPTION
Adds **[Headroom](https://github.com/patwalls/headroom)** to `applications.json` (categories: menubar, development), per the contribution guidelines.

Headroom shows Claude Code's 5-hour session and 7-day weekly utilization as a live percentage in the macOS menu bar — color-coded as a limit approaches, with reset countdowns. Zero config, zero network: it reads the usage numbers Claude Code's own status line writes to disk locally — no API key, no Keychain, no network calls ever. MIT licensed, ~460 lines of dependency-free AppKit Swift, signed & notarized, active development.

The screenshot URL is the app's own rendering with real data: https://headroom.walls.sh/dropdown.png

🤖 Generated with [Claude Code](https://claude.com/claude-code)