### PR TITLE
Add Claude Usage

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,22 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "Claude Usage",
+            "short_description": "Menu bar app that shows your Claude Code usage — current session, weekly, Sonnet, and credits.",
+            "categories": [
+                "menubar"
+            ],
+            "repo_url": "https://github.com/Bread-bang/claude-usage",
+            "icon_url": "https://raw.githubusercontent.com/Bread-bang/claude-usage/main/docs/icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/Bread-bang/claude-usage/main/docs/screenshot.png"
+            ],
+            "official_site": "https://github.com/Bread-bang/claude-usage",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Adds [Claude Usage](https://github.com/Bread-bang/claude-usage) — a native, open-source macOS menu bar app that shows your Claude Code usage (current session, weekly, Sonnet, and credits) at a glance, without launching Claude Code.

- Swift + SwiftUI, no dependencies, no backend or telemetry
- Notarized; installable via `brew install bread-bang/tap/claude-usage`
- MIT licensed

Guidelines: edited `applications.json` (not the README), single suggestion, description ends with a period, category `menubar`.