### PR TITLE
Add Ghostwriter

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -4899,6 +4899,22 @@
             ]
         },
         {
+            "short_description": "Privacy-focused notes overlay that stays hidden from screenshots and screen shares.",
+            "categories": [
+                "notes"
+            ],
+            "repo_url": "https://github.com/evanpizzolato/ghostwriter",
+            "title": "Ghostwriter",
+            "icon_url": "https://raw.githubusercontent.com/evanpizzolato/ghostwriter/main/docs/icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/evanpizzolato/ghostwriter/main/docs/og.png"
+            ],
+            "official_site": "https://evanpizzolato.github.io/ghostwriter/",
+            "languages": [
+                "javascript"
+            ]
+        },
+        {
             "short_description": "Notes manager for macOS/iOS: modern notational velocity (nvALT) on steroids. ",
             "categories": [
                 "notes"


### PR DESCRIPTION
Adds [Ghostwriter](https://github.com/evanpizzolato/ghostwriter) to the notes category.

Privacy-focused notes overlay for macOS — uses OS-level content protection so notes stay hidden from screenshots, recordings, and screen shares. Always-on-top, adjustable transparency, click-through mode. GPL-3.0, JavaScript/Electron, actively maintained, signed & notarized universal releases.

Edited applications.json per the contribution guidelines (one app, period-terminated description).

🤖 Generated with [Claude Code](https://claude.com/claude-code)