### PR TITLE
Add Opening Trainer (chess opening trainer)

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -3548,6 +3548,22 @@
             ]
         },
         {
+            "short_description": "Chess opening trainer: practice your own repertoires with spaced repetition, bundled Stockfish analysis and Lichess explorer.",
+            "categories": [
+                "games"
+            ],
+            "repo_url": "https://github.com/vancoeur/chess-opening-trainer",
+            "title": "Opening Trainer",
+            "icon_url": "https://raw.githubusercontent.com/vancoeur/chess-opening-trainer/main/assets/app_icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/vancoeur/chess-opening-trainer/main/docs/screenshot.en.png"
+            ],
+            "official_site": "",
+            "languages": [
+                "python"
+            ]
+        },
+        {
             "short_description": "Beautiful, powerful chess application.",
             "categories": [
                 "games"


### PR DESCRIPTION
Adds **Opening Trainer** — a free, open-source chess opening trainer for macOS (GPLv3, Python/PySide6).

- Practice your own opening repertoires (PGN) with spaced repetition
- Stockfish bundled: repertoire check, move feedback, evaluation bar, sparring, game review
- Lichess opening explorer integration
- English & German interface, ready-to-run release available

Repo: https://github.com/vancoeur/chess-opening-trainer

Edited `applications.json` only, one suggestion, format as in the contribution guidelines.