### PR TITLE
Add Better Resource Monitor

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -9446,6 +9446,27 @@
             ]
         },
         {
+            "short_description": "Lightweight macOS menu bar monitor for CPU, memory, storage, GPU, and network usage.",
+            "categories": [
+                "system",
+                "utilities",
+                "menubar"
+            ],
+            "repo_url": "https://github.com/alexx855/better-resource-monitor",
+            "title": "Better Resource Monitor",
+            "icon_url": "https://raw.githubusercontent.com/alexx855/better-resource-monitor/main/src-tauri/icons/icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/alexx855/better-resource-monitor/main/images/appstore/en/performance.png",
+                "https://raw.githubusercontent.com/alexx855/better-resource-monitor/main/images/appstore/en/privacy.png",
+                "https://raw.githubusercontent.com/alexx855/better-resource-monitor/main/images/appstore/en/simplicity.png"
+            ],
+            "official_site": "https://better-resource-monitor.alexpedersen.dev/",
+            "languages": [
+                "rust",
+                "typescript"
+            ]
+        },
+        {
             "short_description": "macOS system monitor in your menu bar",
             "categories": [
                 "system",


### PR DESCRIPTION
## Project URL
https://github.com/alexx855/better-resource-monitor

## Category
system, utilities, menubar

## Description
Better Resource Monitor is a free open-source macOS menu bar monitor for CPU, memory, storage, GPU, and network usage. It is built with Rust and Tauri, available on the Mac App Store and GitHub Releases, and designed to run quietly without telemetry.

## Why it should be included to `Awesome macOS open source applications` (optional)
It is a recently maintained MIT-licensed macOS utility with a clear English README, public source code, and App Store distribution.

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English