### PR TITLE
Add FotoApp

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -3920,6 +3920,20 @@
             ]
         },
         {
+            "short_description": "Local-only photo and video organizer with duplicate detection, GPS map, RAW support and Google Takeout import. No cloud or account.",
+            "categories": [
+                "images"
+            ],
+            "repo_url": "https://github.com/boulbaal/fotoApp",
+            "title": "FotoApp",
+            "icon_url": "https://raw.githubusercontent.com/boulbaal/fotoApp/main/build/icon.png",
+            "screenshots": [],
+            "official_site": "https://boulbaal.github.io/fotoApp/",
+            "languages": [
+                "javascript"
+            ]
+        },
+        {
             "short_description": "Insane(ly slow but wicked good) PNG image optimization. ",
             "categories": [
                 "images"


### PR DESCRIPTION
Adds **FotoApp** (category: images).

Free, open-source (ISC) local-only photo & video organizer for macOS (also Windows/Linux): duplicate detection, GPS map (OpenStreetMap), RAW support, Google Takeout import, smart export. No cloud, no account, no telemetry.

Edited `applications.json` per CONTRIBUTING. Disclosure: I'm the author.

Repo: https://github.com/boulbaal/fotoApp