### PR TITLE
Add LeftHandy - Left-handed cursor and mouse button support for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -7350,6 +7350,12 @@ You can see in which language an app is written. Currently there are following l
   </p>
   </details>
 
+- [LeftHandy](https://github.com/writronic/LeftHandy) - Left-handed cursor and mouse button support for macOS.
+
+  **Languages:** <img src='./icons/swift-64.png' alt='Swift icon' title='Swift' height='16'/> Swift <img src='./icons/objective-c-64.png' alt='Objective-C icon' title='Objective-C' height='16'/> Objective-C 
+
+  **Website:** [https://writronic.com/lefthandy/](https://writronic.com/lefthandy/)
+
 - [Loading](https://github.com/BonzaiThePenguin/Loading) - Simple network activity monitor for macOS. 
 
   **Languages:** <img src='./icons/objective-c-64.png' alt='Objective-C icon' title='Objective-C' height='16'/> Objective-C 
@@ -8205,6 +8211,12 @@ You can see in which language an app is written. Currently there are following l
 
   </p>
   </details>
+
+- [LeftHandy](https://github.com/writronic/LeftHandy) - Left-handed cursor and mouse button support for macOS.
+
+  **Languages:** <img src='./icons/swift-64.png' alt='Swift icon' title='Swift' height='16'/> Swift <img src='./icons/objective-c-64.png' alt='Objective-C icon' title='Objective-C' height='16'/> Objective-C 
+
+  **Website:** [https://writronic.com/lefthandy/](https://writronic.com/lefthandy/)
 
 - [LocationSimulator](https://github.com/Schlaubischlump/LocationSimulator) - Application to spoof your iOS or iPhoneSimulator location.
 


### PR DESCRIPTION
## Project URL
https://github.com/writronic/LeftHandy

## Category
utilities, system

## Description
LeftHandy is a menu bar app that adds left-handed mouse and cursor support to your Mac. It mirrors all system cursors so the tip points naturally for left-handed use, swaps left and right click in real time via a low-level event tap, and automatically reapplies flipped cursors after display reconfiguration, app switches, and wake from sleep. Written in Swift and Objective-C, requires macOS 14 Sonoma or later.

## Why it should be included to `Awesome macOS open source applications` (optional)
LeftHandy fills a unique accessibility gap for left-handed macOS users. It is the only open-source app that combines cursor flipping with mouse button swapping in a lightweight menu bar utility. It is code-signed, notarized, and supports macOS Tahoe.

## Checklist
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [ ] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English