### PR TITLE
Add MaCursor - Custom cursor themes for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -8238,6 +8238,21 @@ You can see in which language an app is written. Currently there are following l
   </p>
   </details>
 
+- [MaCursor](https://github.com/writronic/MaCursor) - Custom cursor themes for macOS. MaCursor lets you replace every macOS system cursor — arrow, I-beam, crosshair, wait spinner, and more — with custom artwork of your own.
+
+  **Languages:** <img src='./icons/swift-64.png' alt='Swift icon' title='Swift' height='16'/> Swift <img src='./icons/objective-c-64.png' alt='Objective-C icon' title='Objective-C' height='16'/> Objective-C 
+
+  **Website:** [https://writronic.com/macursor/](https://writronic.com/macursor/)
+
+  <details>
+  <summary>Screenshots</summary>
+  <p>
+
+  <img src='https://github.com/writronic/MaCursor/raw/main/screenshot.png' width='400' loading='lazy' decoding='async' fetchpriority='low'/>
+
+  </p>
+  </details>
+
 - [macOS GateKeeper Helper](https://github.com/wynioux/macOS-GateKeeper-Helper) - Simple macOS GateKeeper script. It helps you to control your GateKeeper.
 
   **Languages:** <img src='./icons/shell-64.png' alt='Shell icon' title='Shell' height='16'/> Shell 


### PR DESCRIPTION
## Project URL
https://github.com/writronic/MaCursor

## Category
utilities, system

## Description
Custom cursor themes for macOS. MaCursor lets you replace every macOS system cursor — arrow, I-beam, crosshair, wait spinner, and more — with custom artwork of your own. Browse 75+ ready-to-apply themes, import Windows `.cur` / `.ani` cursor files, design your own from scratch in the visual editor, and switch between themes instantly with global hotkeys. Written in Swift and Objective-C, requires macOS 15 Sequoia or later.

## Why it should be included to `Awesome macOS open source applications` (optional)
MaCursor is a unique, actively maintained open-source macOS utility that fills a gap in cursor customization. It is code-signed, notarized, supports 10 languages, and offers features not available in any other open-source macOS app (theme gallery, Windows cursor import, visual editor, global hotkeys).

## Checklist
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English