### PR TITLE
Add Fabar - per-app volume control for macOS

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -666,6 +666,24 @@
             ]
         },
         {
+            "title": "Fabar",
+            "short_description": "Per-app volume control from the menu bar. Uses Core Audio process taps instead of a virtual audio driver.",
+            "categories": [
+                "audio",
+                "menubar",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/gigaptera/fabar",
+            "icon_url": "https://raw.githubusercontent.com/gigaptera/fabar/main/fabar-app/web-icons/icon-256.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/gigaptera/fabar/main/docs/assets/screenshot-dark.png"
+            ],
+            "official_site": "https://fabar.gigaptera.com",
+            "languages": [
+                "swift"
+            ]
+        },
+        {
             "short_description": "macOS camera recording using ffmpeg ",
             "categories": [
                 "audio"


### PR DESCRIPTION
**[Fabar](https://github.com/gigaptera/fabar)** — Free, MIT-licensed, open-source per-app volume control for macOS.

- Menu bar app with a volume slider for every app playing audio
- Uses Core Audio process taps (macOS 14.4+) — no virtual audio driver, nothing added to your output device list
- Apps you never adjust stay on the native audio path
- Boost quiet apps up to 200%
- Swift / SwiftUI, signed & notarized DMG

Added to `applications.json` with categories: `audio`, `menubar`, `utilities`.