### PR TITLE
Add Agent Island

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -17,6 +17,26 @@
             ]
         },
 	{
+            "title": "Agent Island",
+            "short_description": "MacBook notch companion for Claude and Codex sessions with live status and auto-resume.",
+            "categories": [
+                "development",
+                "menubar",
+                "productivity",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/tristan666666/agent-island",
+            "icon_url": "https://raw.githubusercontent.com/tristan666666/agent-island/main/Resources/agentisland_logo.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/tristan666666/agent-island/main/Assets/agent-island-usage.png",
+                "https://raw.githubusercontent.com/tristan666666/agent-island/main/Assets/agent-island-auto-trigger.png"
+            ],
+            "official_site": "https://github.com/tristan666666/agent-island",
+            "languages": [
+                "swift"
+            ]
+        },
+	{
             "short_description": "Clipboard history manager for macOS with terminal-style navigation, image previews, and cursor-following popup.",
             "categories": [
                 "utilities",


### PR DESCRIPTION
Adds Agent Island to applications.json.

Agent Island is an open-source native macOS app built with Swift/SwiftUI. It lives in the MacBook notch and helps monitor Claude/Codex sessions with live status plus optional auto-resume for selected long-running sessions.