### PR TITLE
Add Agent Island

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -18,7 +18,7 @@
         },
         {
             "title": "Agent Island",
-            "short_description": "Native macOS notch companion for Claude Code and Codex session status plus auto-resume.",
+            "short_description": "Native macOS notch companion for Claude Code and Codex: live session status, turn alarms, quota tracking with out-of-quota alerts, and auto-resume.",
             "categories": [
                 "development",
                 "menubar",
@@ -31,7 +31,7 @@
                 "https://raw.githubusercontent.com/tristan666666/agent-island/main/Assets/agent-island-auto-trigger.png",
                 "https://raw.githubusercontent.com/tristan666666/agent-island/main/Assets/agent-island-usage.png"
             ],
-            "official_site": "https://github.com/tristan666666/agent-island",
+            "official_site": "https://agent-island.dev",
             "languages": [
                 "swift"
             ]

--- a/applications.json
+++ b/applications.json
@@ -16,6 +16,26 @@
                 "typescript"
             ]
         },
+        {
+            "title": "Agent Island",
+            "short_description": "Native macOS notch companion for Claude Code and Codex session status plus auto-resume.",
+            "categories": [
+                "development",
+                "menubar",
+                "productivity",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/tristan666666/agent-island",
+            "icon_url": "https://raw.githubusercontent.com/tristan666666/agent-island/main/Resources/agentisland_logo.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/tristan666666/agent-island/main/Assets/agent-island-auto-trigger.png",
+                "https://raw.githubusercontent.com/tristan666666/agent-island/main/Assets/agent-island-usage.png"
+            ],
+            "official_site": "https://github.com/tristan666666/agent-island",
+            "languages": [
+                "swift"
+            ]
+        },
 	{
             "short_description": "Clipboard history manager for macOS with terminal-style navigation, image previews, and cursor-following popup.",
             "categories": [
@@ -166,7 +186,7 @@
         {
             "short_description": "Fun Tic Tac Toe game equipped with multiplayer (local and online) and leveled single player available on the App Store.",
             "categories": [
-                "games",
+                "games"
             ],
             "repo_url": "https://github.com/Aries-Sciences-LLC/Tic-Tac-Toe",
             "title": "Amazing Tic Tac Toe",
@@ -184,7 +204,7 @@
         {
             "short_description": "Simple and elegant menubar weather app on the App Store.",
             "categories": [
-                "menubar",
+                "menubar"
             ],
             "repo_url": "https://github.com/Aries-Sciences-LLC/Quick-Weather",
             "title": "Quick Weather",


### PR DESCRIPTION
## Summary
- Add Agent Island, a native macOS notch/menu bar companion for Claude Code and Codex session status and auto-resume.
- Include the project icon and screenshots from the upstream repository.
- Fix two existing trailing commas in nearby category arrays so applications.json parses as valid JSON.

## Checks
- Searched for an existing Agent Island entry.
- Ran `jq empty applications.json`.
- Ran `git diff --check`.