### PR TITLE
Add Fabar — per-app volume control

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -702,6 +702,22 @@
             ]
         },
         {
+            "short_description": "Per-app volume control from the menu bar. No virtual audio driver — uses Core Audio process taps.",
+            "categories": [
+                "audio"
+            ],
+            "repo_url": "https://github.com/gigaptera/fabar",
+            "title": "Fabar",
+            "icon_url": "",
+            "screenshots": [
+                "https://raw.githubusercontent.com/gigaptera/fabar/main/docs/assets/screenshot-dark.png"
+            ],
+            "official_site": "https://fabar.gigaptera.com",
+            "languages": [
+                "swift"
+            ]
+        },
+        {
             "short_description": "The fre:ac audio converter project. ",
             "categories": [
                 "audio"


### PR DESCRIPTION
Fabar is a free, MIT-licensed macOS menu bar app for per-app volume control.

Uses the Core Audio process-tap API instead of a virtual audio driver, so apps
you don't adjust stay on the native audio path.

- Category: Audio
- Language: Swift
- License: MIT
- macOS 14.4+

Repository: https://github.com/gigaptera/fabar
Website: https://fabar.gigaptera.com