### PR TITLE
Add Tintpad

### DIFF
--- a/README.md
+++ b/README.md
@@ -5819,7 +5819,7 @@ You can see in which language an app is written. Currently there are following l
   </p>
   </details>
 
-### ⏱️ Productivity (78)
+### ⏱️ Productivity (79)
 - [ActivityWatch](https://github.com/ActivityWatch/activitywatch) - Open-source automated time tracker that tracks how you spend time on your devices.
 
   **Languages:** <img src='./icons/python-64.png' alt='Python icon' title='Python' height='16'/> Python <img src='./icons/typescript-64.png' alt='TypeScript icon' title='TypeScript' height='16'/> TypeScript 
@@ -6668,6 +6668,8 @@ You can see in which language an app is written. Currently there are following l
 
   </p>
   </details>
+
+- [Tintpad](https://github.com/sorkila/tintpad) - Hotkey launcher that opens your terminal at the right repo with a coding agent (Claude Code, Codex) already running.
 
 - [Toggl Desktop](https://github.com/toggl-open-source/toggldesktop) - Toggl Desktop app for Windows, Mac and Linux. 
 


### PR DESCRIPTION
Adds **Tintpad** to applications.json (README regenerates on merge per CONTRIBUTING).

Native macOS menu-bar launcher: a hotkey opens your terminal at the right repo with a coding agent (Claude Code, Codex) already running. Frecency repo search, run modes, git worktrees, headless dispatch. Open source (MIT), signed + notarized.

- Repo: https://github.com/sorkila/tintpad
- Categories: terminal, development. Sits alongside OpenInTerminal / Finder Go.