### PR TITLE
Add JsonStudio

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -3014,6 +3014,26 @@
             ]
         },
         {
+            "short_description": "Local-first JSON workspace for formatting, editing, diffing, converting, validating, and extracting JSON from logs.",
+            "categories": [
+                "json",
+                "json-parsing",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/sundegan/JsonStudio",
+            "title": "JsonStudio",
+            "icon_url": "https://raw.githubusercontent.com/sundegan/JsonStudio/main/docs/icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/sundegan/JsonStudio/main/docs/media/jsonstudio-demo.gif"
+            ],
+            "official_site": "https://jsonstudio.js.org/",
+            "languages": [
+                "rust",
+                "typescript",
+                "svelte"
+            ]
+        },
+        {
             "short_description": "Dead simple JSON editor using josdejong/jsoneditor",
             "categories": [
                 "json"


### PR DESCRIPTION
## Project URL

https://github.com/sundegan/JsonStudio

## Category

development, json-parsing, editors/json, utilities

## Description

JsonStudio is a local-first desktop JSON workspace for formatting, editing, diffing, converting, validating, and extracting JSON from logs.

Official website: https://jsonstudio.js.org/

## Why it should be included to `Awesome macOS open source applications ` (optional)

JsonStudio is an open-source macOS desktop app built with Tauri and Svelte for everyday JSON workflows. It keeps data local and supports common developer tasks around JSON inspection, conversion, validation, comparison, and log extraction.

## Checklist

- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] The application is open source and has a macOS version.
- [X] I have searched the list and confirmed this application is not already included.
- [X] Screenshots added if any.
