### PR TITLE
Add Walter

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,5 +1,20 @@
 {
     "applications": [
+        {
+            "title": "Walter",
+            "short_description": "Native launcher and Spotlight, Alfred and Raycast alternative; no Electron, no accounts, no telemetry, configured in a TOML file.",
+            "categories": [
+                "productivity",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/ekinertac/walter",
+            "icon_url": "https://raw.githubusercontent.com/ekinertac/walter/master/walter-icon.png",
+            "screenshots": [],
+            "official_site": "https://walterlauncher.com",
+            "languages": [
+                "swift"
+            ]
+        },
 	{
             "title": "ActivityWatch",
             "short_description": "Open-source automated time tracker that tracks how you spend time on your devices.",


### PR DESCRIPTION
## Project URL
https://github.com/ekinertac/walter

## Category
productivity, utilities

## Description
Walter is a native, open-source (MIT) macOS launcher — a Spotlight, Alfred and Raycast alternative written in pure Swift + AppKit. It is around 4.3 MB with no Electron, no accounts, and no telemetry, and is configured entirely through a plain-text TOML file. It does fuzzy app launching, System Settings panes, system commands, calculator, unit and currency conversion, custom aliases, and web-search fallback, with 21 built-in themes.

## Checklist
- [x] Edit applications.json instead of README.md
- [x] Only one project/change is in this pull request
- [x] Has a commit from less than 2 years ago
- [x] Has a clear README in English