### PR TITLE
Add mysa

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,6 +1,23 @@
 {
     "applications": [
 	{
+            "title": "mysa",
+            "short_description": "A macOS menu bar app for quick breathing breaks, with a frosted screen overlay and handwritten quotes.",
+            "categories": [
+                "productivity",
+                "menubar"
+            ],
+            "repo_url": "https://github.com/alishansnsn/mysa",
+            "icon_url": "https://raw.githubusercontent.com/alishansnsn/mysa/main/logoicon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/alishansnsn/mysa/main/demo-poster.jpg"
+            ],
+            "official_site": "https://github.com/alishansnsn/mysa",
+            "languages": [
+                "swift"
+            ]
+        },
+	{
             "title": "ActivityWatch",
             "short_description": "Open-source automated time tracker that tracks how you spend time on your devices.",
             "categories": [


### PR DESCRIPTION
## Project URL
https://github.com/alishansnsn/mysa

## Category
productivity, menubar

## Description
mysa is a small macOS menu bar app for taking quick breathing breaks. You press a hotkey, the screen dims behind a frosted overlay, a small orb breathes in and out in the notch, and a short handwritten quote draws itself on screen while you breathe. It is open source under the MIT license, free, and built in Swift and SwiftUI for macOS 14 and newer.

## Why it should be included to `Awesome macOS open source applications ` (optional)
It is a focused, fully open source native macOS utility with a clear README and an active repository.

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
