### PR TITLE
Add Mimer

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -5648,6 +5648,23 @@
             ]
         },
         {
+            "short_description": "Fast, private, developer-first clipboard manager with type-aware history, ⌘K transforms, and history encrypted at rest.",
+            "categories": [
+                "productivity",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/hasanjafri/Mimer",
+            "title": "Mimer",
+            "icon_url": "https://raw.githubusercontent.com/hasanjafri/Mimer/main/Sources/Mimer/Assets.xcassets/AppIcon.appiconset/icon_256.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/hasanjafri/Mimer/main/docs/media/hero.png"
+            ],
+            "official_site": "https://mimer.hasanjafri.com/",
+            "languages": [
+                "swift"
+            ]
+        },
+        {
             "short_description": "macOS open source clipboard manager",
             "categories": [
                 "productivity"


### PR DESCRIPTION
Adding **Mimer**, a free and open-source (MIT) clipboard manager for macOS, to `applications.json` (right after Maccy).

- **Repo:** https://github.com/hasanjafri/Mimer
- **Site:** https://mimer.hasanjafri.com/
- **Categories:** productivity, utilities · **Language:** Swift

A native SwiftUI/AppKit menu-bar app: type-aware clipboard history, a ⇧⌘V command palette with ⌘K transforms, scoped search, and history encrypted at rest. Edited `applications.json` only (not README.md), per the contribution guidelines.