### PR TITLE
Add Kaset (native YouTube Music and YouTube client)

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,23 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "short_description": "Native macOS client for YouTube Music and YouTube, built with Swift and SwiftUI.",
+            "categories": [
+                "music",
+                "video"
+            ],
+            "repo_url": "https://github.com/sozercan/kaset",
+            "title": "Kaset",
+            "icon_url": "",
+            "screenshots": [
+                "https://raw.githubusercontent.com/sozercan/kaset/main/docs/screenshot.png"
+            ],
+            "official_site": "https://github.com/sozercan/kaset",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Adds [Kaset](https://github.com/sozercan/kaset) to `applications.json`.

Kaset is a native macOS client for **YouTube Music and YouTube**, built with Swift and SwiftUI (MIT-licensed, actively maintained). It plays YouTube Music via your existing Premium subscription and now includes a full native YouTube video experience — browsing, search, subscriptions, Shorts, comments, and video playback with native controls, captions, quality selection, and picture in picture.

### Checklist
- [x] Edited `applications.json` (not `README.md`)
- [x] Individual PR for a single suggestion
- [x] Categories use existing ids from `categories.json` (`music`, `video`)
- [x] Description is short and ends with a period
- [x] Open-source (MIT) with recent commits, builds in current Xcode, English README