### PR TITLE
Add Hangar

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,21 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "short_description": "Menu bar launcher for one-click, toggleable terminal and app snippets.",
+            "categories": [
+                "menubar",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/0fuz/hangar",
+            "title": "Hangar",
+            "icon_url": "",
+            "screenshots": [],
+            "official_site": "https://github.com/0fuz/hangar",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Adds **Hangar** to `applications.json` (categories: menubar, utilities) — a native Swift/AppKit menu bar app that launches your terminal and app workflows as one-click, toggleable snippets (with `{{name}}` command parameters, groups, and auto-start). Open source, MIT: https://github.com/0fuz/hangar