### PR TITLE
Add Blurt

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,5 +1,20 @@
 {
     "applications": [
+        {
+            "title": "Blurt",
+            "short_description": "Dictation app: hold a hotkey, speak, and cleaned-up text is pasted into the focused app. Uses AssemblyAI Sync STT (bring your own key).",
+            "categories": [
+                "audio",
+                "productivity"
+            ],
+            "repo_url": "https://github.com/alexkroman/blurt",
+            "icon_url": "",
+            "screenshots": [],
+            "official_site": "https://blurtblurt.com",
+            "languages": [
+                "swift"
+            ]
+        },
 	{
             "title": "ActivityWatch",
             "short_description": "Open-source automated time tracker that tracks how you spend time on your devices.",


### PR DESCRIPTION
Adds [Blurt](https://github.com/alexkroman/blurt) to `applications.json`.

Blurt is a small, open-source (MIT) macOS dictation app written in Swift: hold a hotkey, speak, and cleaned-up text is pasted into the focused app. It uses AssemblyAI's Sync speech-to-text (bring your own key — free tier to start).

- Repo: https://github.com/alexkroman/blurt
- Site: https://blurtblurt.com
- Language: Swift · License: MIT · Categories: audio, productivity

Per CONTRIBUTING: edited `applications.json` (not the generated README), individual PR for this one suggestion, description ends with a period, no trailing whitespace.