### PR TITLE
Add Edmund

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,5 +1,18 @@
 {
     "applications": [
+        {
+            "title": "Edmund",
+            "short_description": "Minimal, native macOS Markdown editor with live preview that works with your existing files, no vault.",
+            "categories": [
+                "markdown"
+            ],
+            "repo_url": "https://github.com/I7T5/Edmund",
+            "screenshots": [],
+            "official_site": "https://github.com/I7T5/Edmund",
+            "languages": [
+                "swift"
+            ]
+        },
 	{
             "title": "ActivityWatch",
             "short_description": "Open-source automated time tracker that tracks how you spend time on your devices.",


### PR DESCRIPTION
Adds [Edmund](https://github.com/I7T5/Edmund), a free, open-source, native macOS Markdown editor (Swift) with live preview — no vault, just your files. Edited `applications.json` per CONTRIBUTING, category `markdown`. I left out `icon_url` for now (no hosted icon URL yet) and used the repo as `official_site`; happy to add an icon if you'd prefer.