### PR TITLE
Add Rockxy

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -2698,6 +2698,23 @@
             ]
         },
         {
+            "short_description": "Open-source native macOS debugging proxy for inspecting HTTP, HTTPS, WebSocket, and GraphQL traffic.",
+            "categories": [
+                "web-development",
+                "vpn--proxy"
+            ],
+            "repo_url": "https://github.com/RockxyApp/Rockxy",
+            "title": "Rockxy",
+            "icon_url": "https://raw.githubusercontent.com/RockxyApp/Rockxy/main/docs/logo/logo.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/RockxyApp/Rockxy/main/docs/images/Rockxy-Light.png"
+            ],
+            "official_site": "https://rockxy.io",
+            "languages": [
+                "swift"
+            ]
+        },
+        {
             "short_description": "A lightweight open-source API Development, Testing & Mocking platform",
             "categories": [
                 "web-development"


### PR DESCRIPTION
## Project URL
https://github.com/RockxyApp/Rockxy

## Category
web-development, vpn--proxy

## Description
Rockxy is an open-source native macOS debugging proxy for inspecting HTTP, HTTPS, WebSocket, and GraphQL traffic.

## Why it should be included to `Awesome macOS open source applications` (optional)
Rockxy is an AGPL-3.0 native Swift macOS app for local-first API and app traffic debugging, with a clear English README and recent releases.

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English