### PR TITLE
Add MoonProxy — GUI desktop client for FRP

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,24 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "MoonProxy",
+            "short_description": "Cross-platform GUI desktop client for FRP (frpc) intranet exposure. Turn your local services into public addresses with one click.",
+            "categories": [
+                "utilities",
+                "vpn--proxy"
+            ],
+            "repo_url": "https://github.com/MoonProxyHQ/moonproxy-desktop",
+            "icon_url": "https://moonproxy.app/favicon.svg",
+            "screenshots": [
+                "https://moonproxy.app/screenshots/main-full-en.jpg"
+            ],
+            "official_site": "https://moonproxy.app",
+            "languages": [
+                "rust",
+                "typescript"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Adds **MoonProxy** to , categorized under  and .

## About

MoonProxy (月神代理) is a cross-platform **GUI desktop client for FRP** (). It turns intranet exposure into a single click — add a tunnel like filling in a form, start it like a light switch. Built with **Tauri v2 + Vue 3 + Rust + TypeScript**, MIT licensed, for **macOS (Apple Silicon + Intel) and Windows**.

## Compliance with CONTRIBUTING.md

- ✅ Edited `applications.json` (not README.md)
- ✅ Follows the required JSON schema (title / short_description / categories / repo_url / icon_url / screenshots / official_site / languages)
- ✅ Description ends with a period
- ✅ Active repository with recent commits
- ✅ English README available ([README.en.md](https://github.com/MoonProxyHQ/moonproxy-desktop/blob/main/README.en.md))
- ✅ MIT licensed
- ✅ Categories use existing slugs (`utilities`, `vpn--proxy`)

## Independence disclosure

MoonProxy is **independent of** `fatedier/frp`. It is only a GUI desktop client; the frpc binary is bundled via the Tauri sidecar mechanism. Documented in the project README.

## Links

- Site: https://moonproxy.app
- Repo: https://github.com/MoonProxyHQ/moonproxy-desktop
- Latest release: https://github.com/MoonProxyHQ/moonproxy-desktop/releases/latest