### PR TITLE
Add Harbofly

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -9144,6 +9144,23 @@
                 "swift"
             ]
         },
+        {
+            "short_description": "Menu bar app and CLI that reclaims disk space from dev build artifacts, caches and AI model weights. Trash-first, git-aware stale project detection.",
+            "categories": [
+                "menubar",
+                "development"
+            ],
+            "repo_url": "https://github.com/carloshpdoc/Harbofly",
+            "title": "Harbofly",
+            "icon_url": "https://harbofly.app/harbofly-icon.png",
+            "screenshots": [
+                "https://harbofly.app/harbofly-demo-en.jpg"
+            ],
+            "official_site": "https://harbofly.app",
+            "languages": [
+                "swift"
+            ]
+        },
 	{
             "short_description": "Powerful menu bar manager for macOS",
             "categories": [


### PR DESCRIPTION
## Project URL
https://github.com/carloshpdoc/Harbofly

## Category
menubar, development

## Description
Harbofly is a free, open-source menu bar app (plus CLI) that reclaims the disk space developer tools hide: build artifacts (DerivedData, node_modules, Gradle), tool caches (npm, Homebrew, SwiftPM, pip) and AI model weights (Ollama, Hugging Face, LM Studio). Everything is grouped by explicit risk tier, goes to the Trash first, and source code is never touched. It detects idle projects from the local git history (warning about uncommitted or unpushed work), explains macOS purgeable space, and offers opt-in auto-clean. Native Swift/SwiftUI, notarized, UI in 6 languages.

## Why it should be included to `Awesome macOS open source applications` (optional)
Actively maintained, notarized (Developer ID) with SLSA build provenance, distributed via Homebrew cask and DMG. Already featured on Awesome Mac.

## Checklist
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English