### PR TITLE
Add tty7 to Terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -7486,7 +7486,7 @@ You can see in which language an app is written. Currently there are following l
 
   **Website:** [https://www.wireshark.org/](https://www.wireshark.org/)
 
-### 📺 Terminal (15)
+### 📺 Terminal (16)
 - [Alacritty](https://github.com/alacritty/alacritty) - Cross-platform, GPU-accelerated terminal emulator. 
 
   **Languages:** <img src='./icons/rust-64.png' alt='Rust icon' title='Rust' height='16'/> Rust 
@@ -7596,6 +7596,7 @@ You can see in which language an app is written. Currently there are following l
   **Languages:** <img src='./icons/swift-64.png' alt='Swift icon' title='Swift' height='16'/> Swift 
 
 - [Tabby](https://github.com/Eugeny/tabby) - Powerful cross-platform terminal emulator, featuring a modern GUI, and offering SSH, serial, Telnet, and SCP client support.
+- [tty7](https://github.com/l0ng-ai/tty7) - A GPU-rendered, daemon-backed terminal in pure Rust; sessions survive quitting the app without tmux.
 
   **Languages:** <img src='./icons/typescript-64.png' alt='TypeScript icon' title='TypeScript' height='16'/> TypeScript 
 


### PR DESCRIPTION
Adds **tty7** — a GPU-rendered, daemon-backed terminal emulator written in pure Rust (built on Zed's gpui and Alacritty's VT core).

A persistent daemon holds the PTYs, so terminal sessions survive quitting the app — no tmux needed. It ships an enhanced prompt (completion, syntax highlighting, history, in-terminal search), tabs, splits, a command palette, 8 themes, and CJK/IME input, with native builds for macOS (signed & notarized), Windows, and Linux.

- Repo: https://github.com/l0ng-ai/tty7
- License: Apache-2.0

Added in alphabetical order, following the list's existing format.
