### PR TITLE
Add Learn To Play It

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -753,6 +753,23 @@
             ]
         },
         {
+            "short_description": "Isolate any instrument from a song, slow it down, and practice your part.",
+            "categories": [
+                "audio",
+                "music"
+            ],
+            "repo_url": "https://github.com/tobycmurray/learn-to-play-it",
+            "title": "Learn To Play It",
+            "icon_url": "https://raw.githubusercontent.com/tobycmurray/learn-to-play-it/main/docs/app_icon.png",
+            "screenshots": [
+                "https://learntoplayit.com/screenshot.png"
+            ],
+            "official_site": "https://learntoplayit.com",
+            "languages": [
+                "python"
+            ]
+        },
+        {
             "short_description": "LocalRadio is software for listening to \"Software-Defined Radio\" on your Mac and mobile devices. ",
             "categories": [
                 "audio"


### PR DESCRIPTION
Adds [Learn To Play It](https://github.com/tobycmurray/learn-to-play-it) — an open-source macOS app that isolates any instrument from a song (AI stem separation), slows it down, pitch-shifts, and loops sections so you can practice your part.

- Categories: audio, music
- Written in Python (PySide6)
- Free and open source (GPL-2.0), Apple Silicon
- Site: https://learntoplayit.com

Entry added to `applications.json` (alphabetically, before LocalRadio), per CONTRIBUTING. Description ends with a period.