### PR TITLE
Add Oats

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -4996,7 +4996,7 @@
             ]
         },
         {
-            "short_description": "Open-source macOS menu bar app for meeting notes with live transcription, speaker labels, AI summaries, and an offline on-device mode.",
+            "short_description": "Open-source local-first macOS meeting-notes app with live transcription, speaker labels, AI summaries, and an offline on-device mode.",
             "categories": [
                 "notes",
                 "productivity",

--- a/applications.json
+++ b/applications.json
@@ -4996,6 +4996,25 @@
             ]
         },
         {
+            "short_description": "Open-source macOS menu bar app for meeting notes with live transcription, speaker labels, AI summaries, and an offline on-device mode.",
+            "categories": [
+                "notes",
+                "productivity",
+                "menubar"
+            ],
+            "repo_url": "https://github.com/ariso-ai/oats",
+            "title": "OATS",
+            "icon_url": "https://raw.githubusercontent.com/ariso-ai/oats/main/src-tauri/icons/icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/ariso-ai/oats/main/docs/assets/screenshot-a.png"
+            ],
+            "official_site": "https://ariso.ai/oats",
+            "languages": [
+                "rust",
+                "typescript"
+            ]
+        },
+        {
             "short_description": "Simplest way to keep notes. ",
             "categories": [
                 "notes"


### PR DESCRIPTION
Adds Oats to `applications.json` as a notes and productivity macOS app, with the target list's existing menubar category.

Oats fits this list because it is an MIT-licensed, open-source local-first macOS meeting-notes app for Apple Silicon: it turns meetings into transcripts, speaker-labeled notes, and AI summaries. Its offline on-device mode is a useful fit for Mac users who want meeting notes without sending recordings off their machine.
