### PR TITLE
Add Transmission Remote GUI (native macOS Transmission client)

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -6161,6 +6161,22 @@
             ]
         },
         {
+            "short_description": "Native SwiftUI macOS remote for the Transmission daemon; a modern transgui alternative.",
+            "categories": [
+                "sharing-files"
+            ],
+            "repo_url": "https://github.com/epaxpax/transmission-remote-gui",
+            "title": "Transmission Remote GUI",
+            "icon_url": "",
+            "screenshots": [
+                "https://epaxpax.github.io/transmission-remote-gui/screenshot.png"
+            ],
+            "official_site": "https://epaxpax.github.io/transmission-remote-gui/",
+            "languages": [
+                "swift"
+            ]
+        },
+        {
             "short_description": "Privacy enhanced BitTorrent client with P2P content discovery. ",
             "categories": [
                 "sharing-files"


### PR DESCRIPTION
Adds **Transmission Remote GUI** to the Sharing Files category — a free, open-source (MIT) native SwiftUI macOS remote for the Transmission BitTorrent daemon (a modern transgui alternative).

Edited `applications.json` per CONTRIBUTING; placed alphabetically after the existing Transmission entry.

- Repo: https://github.com/epaxpax/transmission-remote-gui
- Native SwiftUI, macOS 14+, MIT, free