### PR TITLE
Add Burrete

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,26 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "Burrete",
+            "short_description": "Molecular workspace with Finder Quick Look previews, 3D structures, chemistry grids, and local workflow-artifact inspection.",
+            "categories": [
+                "finder",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/SergeiNikolenko/Burrete",
+            "icon_url": "https://raw.githubusercontent.com/SergeiNikolenko/Burrete/main/apps/desktop/src-tauri/icons/icon.png",
+            "screenshots": [
+                "https://burrete-landing.vercel.app/assets/burrete-quicklook.png",
+                "https://burrete-landing.vercel.app/assets/main-light.png"
+            ],
+            "official_site": "https://burrete-landing.vercel.app/",
+            "languages": [
+                "typescript",
+                "rust",
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Project URL
https://github.com/SergeiNikolenko/Burrete

## Category
finder, utilities

## Description
Burrete is a free MIT-licensed molecular workspace for macOS with Finder Quick Look previews, 3D structures, chemistry grids, and local workflow-artifact inspection.

## Why it should be included
Burrete is actively maintained, has a clear English README, current releases, an application icon, and public screenshots. I maintain the project.

## Checklist
- [x] Edited applications.json instead of README.md.
- [x] Only one project is in this pull request.
- [x] Screenshots are included.
- [x] The project has recent commits.
- [x] The project has a clear README in English.