### PR TITLE
Add SnapState

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,6 +1,26 @@
 {
     "applications": [
 	{
+            "short_description": "Menu bar app that captures and restores macOS workspace layouts, window positions, browser tabs, and multi-monitor setups.",
+            "categories": [
+                "window-management",
+                "productivity",
+                "menubar"
+            ],
+            "repo_url": "https://github.com/SoulSniper-V2/SnapState",
+            "title": "SnapState",
+            "icon_url": "https://raw.githubusercontent.com/SoulSniper-V2/SnapState/main/SnapState/Assets.xcassets/AppIcon.appiconset/icon_512x512.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/SoulSniper-V2/SnapState/main/assets/demo.gif",
+                "https://raw.githubusercontent.com/SoulSniper-V2/SnapState/main/assets/menubar.png",
+                "https://raw.githubusercontent.com/SoulSniper-V2/SnapState/main/assets/settings.png"
+            ],
+            "official_site": "https://getsnapstate.com/",
+            "languages": [
+                "swift"
+            ]
+        },
+	{
             "title": "ActivityWatch",
             "short_description": "Open-source automated time tracker that tracks how you spend time on your devices.",
             "categories": [


### PR DESCRIPTION
## Project URL
https://github.com/SoulSniper-V2/SnapState

## Category
window-management, productivity, menubar

## Description
SnapState is a native macOS menu bar app that captures and restores workspace layouts — window positions, running apps, browser tabs, and multi-monitor setups — with global hotkeys and automation triggers.

## Why it should be included to `Awesome macOS open source applications ` (optional)
Open-source MIT Swift app with a clear README, recent commits, screenshots, and an official site (https://getsnapstate.com/). Strong fit for Window Management and Productivity.

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English