### PR TITLE
Add Moler - NASA-Punk themed macOS disk cleaner

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,22 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "Moler",
+            "short_description": "NASA-Punk themed macOS disk cleaner -- SwiftUI GUI for Mole CLI with system monitoring and disk usage treemap.",
+            "categories": [
+                "utilities"
+            ],
+            "repo_url": "https://github.com/niyongsheng/moler",
+            "icon_url": "https://raw.githubusercontent.com/niyongsheng/moler/main/logo.svg",
+            "screenshots": [
+                "https://github.com/user-attachments/assets/ccc5b553-50e0-4930-b223-98cfb8018824"
+            ],
+            "official_site": "https://niyongsheng.github.io/moler/",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
### Add Moler to the utilities category

[Moler](https://github.com/niyongsheng/moler) is an open-source macOS disk cleanup utility built with SwiftUI, wrapping the battle-tested Mole CLI in a NASA-Punk inspired graphical interface.

- **Real-time system monitoring** — CPU, Memory, Network, Disk metrics
- **Deep scan & cleanup** — Scan directories, review results, reclaim space
- **Build artifact purge** — Xcode, Gradle, CocoaPods and more
- **Disk usage treemap** — Color-coded by file type
- **App bulk-uninstall** — Sorted by size
- **100% native SwiftUI**, macOS 14.0+, MIT License

🤖 Generated with [Claude Code](https://claude.com/claude-code)