### PR TITLE
Add CodexLoginManager

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,23 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "short_description": "Native macOS utility that checks Codex CLI authentication, distinguishes ChatGPT OAuth from API-key mode, finds the active CLI, and launches the official login flow.",
+            "categories": [
+                "development",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/xiaohei210509/CodexLoginManager",
+            "title": "CodexLoginManager",
+            "icon_url": "https://raw.githubusercontent.com/xiaohei210509/CodexLoginManager/main/Resources/AppIcon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/xiaohei210509/CodexLoginManager/main/docs/images/app-screenshot.png"
+            ],
+            "official_site": "https://github.com/xiaohei210509/CodexLoginManager/releases",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
> Disclosure: I am the author and maintainer of CodexLoginManager.

## Project URL
https://github.com/xiaohei210509/CodexLoginManager

Release: [v1.0.0-beta.1](https://github.com/xiaohei210509/CodexLoginManager/releases/tag/v1.0.0-beta.1)

## Category
development, utilities

## Description
Native macOS utility that checks Codex CLI authentication, distinguishes ChatGPT OAuth from API-key mode, finds the active CLI, and launches the official login flow.

## Why it should be included to `Awesome macOS open source applications ` (optional)
CodexLoginManager provides a focused, privacy-conscious native interface for diagnosing Codex CLI authentication and relaunching the official login flow without directly modifying Codex configuration files. A downloadable universal macOS beta is available from GitHub Releases.

## Validation
- The repository's Swift README generator parsed the entry and generated the expected Development and Utilities listings.
- The repository, icon, screenshot, Releases page, and tagged beta release are publicly accessible.
- `git diff --check` passes.

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
