### PR TITLE
Add Off Grid AI Desktop - private on-device AI app for Mac

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -10153,6 +10153,24 @@
             ]
         },
         {
+            "title": "Off Grid AI Desktop",
+            "short_description": "Private on-device AI suite for Apple Silicon Macs: local LLM chat via llama.cpp, RAG search over your own data, MCP connectors, and Stable Diffusion image generation, with no account, no telemetry, and no cloud.",
+            "categories": [
+                "chat",
+                "development",
+                "productivity"
+            ],
+            "repo_url": "https://github.com/off-grid-ai/off-grid-ai-desktop",
+            "icon_url": "https://raw.githubusercontent.com/off-grid-ai/off-grid-ai-desktop/main/resources/icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/off-grid-ai/off-grid-ai-desktop/main/docs/screenshots/02-chat.png"
+            ],
+            "official_site": "https://getoffgridai.co/desktop",
+            "languages": [
+                "typescript"
+            ]
+        },
+        {
             "short_description": "Simple SQL Client for lightweight data analysis.",
             "categories": [
                 "database"


### PR DESCRIPTION
Adds Off Grid AI Desktop to applications.json. It is an open-source (AGPL-3.0) macOS app for Apple Silicon that runs a local AI suite entirely on-device: local LLM chat via llama.cpp, RAG search over your own data, MCP connectors, and Stable Diffusion image generation. There is no account, no telemetry, and no cloud.

Categorized under chat, development, and productivity, next to peers like M-Courtyard (also a local-LLM macOS app already listed). The entry follows the applications.json schema field-for-field.

Disclosure: I'm involved with the project.