### PR TITLE
Add Nimclip

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -5648,6 +5648,26 @@
             ]
         },
         {
+            "short_description": "Native, local-first clipboard history manager with search, tags, image support, and quick paste.",
+            "categories": [
+                "productivity",
+                "utilities",
+                "menubar"
+            ],
+            "repo_url": "https://github.com/hukdoesn/Nimclip",
+            "title": "Nimclip",
+            "icon_url": "https://raw.githubusercontent.com/hukdoesn/Nimclip/main/Cliplet/Assets.xcassets/NimclipAppIcon.imageset/nimclip-app-icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/hukdoesn/Nimclip/main/docs/images/nimclip-macbook-themes.png",
+                "https://raw.githubusercontent.com/hukdoesn/Nimclip/main/docs/images/nimclip-image-preview-real.png"
+            ],
+            "official_site": "https://hukdoesn.github.io/Nimclip/",
+            "languages": [
+                "swift"
+            ],
+            "macos_version": "15.0+"
+        },
+        {
             "short_description": "macOS open source clipboard manager",
             "categories": [
                 "productivity"


### PR DESCRIPTION
Adds Nimclip to `applications.json`.

Nimclip is a native, local-first clipboard history manager for macOS, built with Swift and SwiftUI. The entry includes its repository, official site, icon, screenshots, categories, language, and minimum macOS version.

The project is actively maintained, Apache-2.0 licensed, and has an English README.

## Screenshots

![Nimclip main interface](https://raw.githubusercontent.com/hukdoesn/Nimclip/main/docs/images/nimclip-main-real.png)

![Nimclip themes](https://raw.githubusercontent.com/hukdoesn/Nimclip/main/docs/images/nimclip-macbook-themes.png)

![Nimclip image preview](https://raw.githubusercontent.com/hukdoesn/Nimclip/main/docs/images/nimclip-image-preview-real.png)