### PR TITLE
Add OpenHabitTracker - notes, tasks and habit tracking

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,24 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "OpenHabitTracker",
+            "short_description": "Take notes, plan tasks, track habits. Free, open source, all data stays on your device.",
+            "categories": [
+                "productivity",
+                "notes"
+            ],
+            "repo_url": "https://github.com/Jinjinov/OpenHabitTracker",
+            "icon_url": "https://raw.githubusercontent.com/Jinjinov/OpenHabitTracker/main/net.openhabittracker.OpenHabitTracker.svg",
+            "screenshots": [
+                "https://openhabittracker.net/images/desktop_7_habits.png",
+                "https://openhabittracker.net/images/desktop_3_notes.png"
+            ],
+            "official_site": "https://openhabittracker.net",
+            "languages": [
+                "c_sharp"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Project URL
https://github.com/Jinjinov/OpenHabitTracker

## Category
productivity, notes

## Description
OpenHabitTracker is a free, open source app for taking notes, planning tasks and tracking habits. Notes support Markdown, tasks have checklist items and time tracking, and habits are tracked by comparing the time since the last completion to a desired repeat interval. All data is stored locally, with no account and no ads. The macOS app is on the Mac App Store; the same app also runs on Windows, Linux, iOS, Android and the web.

## Checklist
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English
