### PR TITLE
Add Deckle

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -4675,6 +4675,23 @@
             ]
         },
         {
+            "short_description": "Subtle paper-grain texture overlay for the whole screen. Click-through menu bar app with 18 textures, global hotkey, and per-display control.",
+            "categories": [
+                "menubar",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/YellowFoxH4XOR/deckle",
+            "title": "Deckle",
+            "icon_url": "https://raw.githubusercontent.com/YellowFoxH4XOR/deckle/main/docs/icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/YellowFoxH4XOR/deckle/main/docs/menu.png"
+            ],
+            "official_site": "https://projects.akshatkatiyar.com/projects/deckle/",
+            "languages": [
+                "swift"
+            ]
+        },
+        {
             "short_description": "Deezer Desktop app for Windows, Linux and macOS. ",
             "categories": [
                 "music"


### PR DESCRIPTION
Adds **[Deckle](https://github.com/YellowFoxH4XOR/deckle)** — a free, MIT-licensed menu bar app that lays a subtle procedural paper-grain texture over the entire screen so long reading sessions feel more like paper than backlit glass. Click-through, 18 textures, global hotkey, multi-display, signed & notarized, universal binary. Pure Swift (AppKit + SwiftUI), no dependencies.

Per CONTRIBUTING.md: edited `applications.json` only, one app per PR, categories from `categories.json` (`menubar`, `utilities`).