### PR TITLE
Add AutoDoc

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -17,6 +17,26 @@
             ]
         },
 	{
+            "title": "AutoDoc",
+            "short_description": "Private, local-first meeting notes with on-device transcription and AI summaries.",
+            "categories": [
+                "productivity",
+                "notes",
+                "menubar"
+            ],
+            "repo_url": "https://github.com/DuetDisplay/AutoDoc",
+            "icon_url": "https://raw.githubusercontent.com/DuetDisplay/AutoDoc/main/docs/assets/logo.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/DuetDisplay/AutoDoc/main/docs/assets/screenshots/notes.png",
+                "https://raw.githubusercontent.com/DuetDisplay/AutoDoc/main/docs/assets/screenshots/transcript.png"
+            ],
+            "official_site": "https://getautodoc.com/",
+            "languages": [
+                "typescript",
+                "swift"
+            ]
+        },
+	{
             "short_description": "Clipboard history manager for macOS with terminal-style navigation, image previews, and cursor-following popup.",
             "categories": [
                 "utilities",


### PR DESCRIPTION
## Project URL
https://github.com/DuetDisplay/AutoDoc

## Category
productivity, notes, menubar

## Description
AutoDoc is a free, open-source local-first meeting assistant for macOS. It records meetings, transcribes speech on-device, labels speakers, and creates structured notes and summaries without a cloud bot or API keys.

## Why it should be included to `Awesome macOS open source applications`
AutoDoc is a current, English-language AGPL-licensed macOS app with a public release. Its local-only workflow fits the Productivity, Notes, and Menubar categories.

## Checklist
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English

Disclosure: I maintain AutoDoc.