### PR TITLE
Add KIAgent

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -271,6 +271,23 @@
             ]
         },
         {
+            "short_description": "Personal digital memory: indexes your mail, chats and documents into a local SQLite database and serves them to AI assistants over MCP.",
+            "categories": [
+                "productivity",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/edjafarov/kiagent-core",
+            "title": "KIAgent",
+            "icon_url": "https://raw.githubusercontent.com/edjafarov/kiagent-core/dev/assets/icon.png",
+            "screenshots": [
+               "https://raw.githubusercontent.com/edjafarov/kiagent-core/dev/docs/assets/readme/hero.png"
+            ],
+            "official_site": "https://localkiagent.com",
+            "languages": [
+                "typescript"
+            ]
+        },
+        {
             "short_description": "Keka is a full featured file archiver, as easy as it can be.",
             "categories": [
                 "utilities"


### PR DESCRIPTION
Adds [KIAgent](https://github.com/edjafarov/kiagent-core) to `applications.json` per the contribution guidelines (categories: productivity, utilities).

KIAgent is an MIT-licensed desktop app that indexes personal data (mail, chats, documents) into a local SQLite database on your machine — on-device parsing/OCR via llama.cpp — and serves it to AI assistants over MCP. Website: https://localkiagent.com · Data-flow docs: https://localkiagent.com/data

Note: the entry was inserted textually (next to Keka) because `applications.json` currently has a pre-existing syntax error at line ~169 (trailing comma inside "Amazing Tic Tac Toe"'s categories array), so it can't be parsed and re-serialized; happy to rebase or move the entry if you prefer.