### PR TITLE
Add Flowtake

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -16,6 +16,24 @@
                 "typescript"
             ]
         },
+        {
+            "title": "Flowtake",
+            "short_description": "Local-first screen recorder and timeline editor for polished developer demos.",
+            "categories": [
+                "video",
+                "editors",
+                "development"
+            ],
+            "repo_url": "https://github.com/JNX03/Flowtake",
+            "icon_url": "https://raw.githubusercontent.com/JNX03/Flowtake/main/src-tauri/icons/128x128%402x.png",
+            "screenshots": [],
+            "official_site": "https://jnx03.github.io/Flowtake/",
+            "languages": [
+                "javascript",
+                "rust",
+                "swift"
+            ]
+        },
 	{
             "short_description": "Clipboard history manager for macOS with terminal-style navigation, image previews, and cursor-following popup.",
             "categories": [


### PR DESCRIPTION
## Description

Adds Flowtake, an MIT-licensed local-first screen recorder and timeline editor for developer demos. The project has a recent release with a universal macOS download and active development.

## Checklist

- searched existing entries and pull requests for duplicates
- added one application entry to `applications.json`
- used existing `video`, `editors`, and `development` categories
- verified the project, website, and icon URLs
- kept the description short and ended it with a period
