### PR TITLE
Add TypeCue

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,21 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "TypeCue",
+            "short_description": "Types a prepared script into any app, one hotkey press per line, as real keystrokes at a human pace, for demo recordings and live presentations.",
+            "categories": [
+                "menubar",
+                "productivity"
+            ],
+            "repo_url": "https://github.com/alexpolonsky/TypeCue",
+            "icon_url": "",
+            "screenshots": [],
+            "official_site": "https://typecue.app",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Project URL
https://github.com/alexpolonsky/TypeCue

## Category
menubar, productivity

## Description
TypeCue is a free, MIT-licensed, open-source macOS (14+) menu bar app that types a prepared script into any app, one global hotkey press per line, as real keystrokes at a human pace, with inline pause and speed markers. Built for demo recordings and live presentations.

## Checklist
- [x] Edited applications.json instead of README.md
- [x] Only one project is added in this pull request
- [x] Has a commit from less than 2 years ago
- [x] Has a clear README in English