### PR TITLE
Add EyeBreak - menu bar 20-20-20 break reminder

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,21 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "EyeBreak",
+            "short_description": "Menu bar 20-20-20 break reminders to reduce digital eye strain. No camera, no network.",
+            "categories": [
+                "menubar",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/sviatil0/eyebreak",
+            "icon_url": "",
+            "screenshots": [],
+            "official_site": "https://github.com/sviatil0/eyebreak",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Project URL
https://github.com/sviatil0/eyebreak

## Category
menubar, utilities

## Description
EyeBreak is an open-source macOS menu-bar app for 20-20-20 screen breaks: every 20 minutes it invites you to look about 20 feet away for 20 seconds, with a gentle full-screen dim overlay and a menu-bar countdown. Breaks can always be snoozed or skipped, and are held automatically while another app is full screen or the screen is mirrored. Written in native Swift with zero third-party dependencies, no camera, and no network access (no analytics or telemetry - everything stays local). MIT licensed.

## Why it should be included to `Awesome macOS open source applications ` (optional)
It is a free, privacy-respecting open-source alternative to paid break-reminder apps such as LookAway, and it deliberately avoids overreaching health claims.

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)