### PR TITLE
Add Performance Monitor to Menubar

### DIFF
--- a/README.md
+++ b/README.md
@@ -4357,7 +4357,7 @@ You can see in which language an app is written. Currently there are following l
   </p>
   </details>
 
-### 📊 Menubar (52)
+### 📊 Menubar (53)
 - [Airpass](https://github.com/alvesjtiago/airpass) - Status bar Mac application to overcome time constrained WiFi networks. 
 
   **Languages:** <img src='./icons/javascript-64.png' alt='JavaScript icon' title='JavaScript' height='16'/> JavaScript 
@@ -4709,6 +4709,7 @@ You can see in which language an app is written. Currently there are following l
   </p>
   </details>
 
+- [Performance Monitor](https://github.com/inequitas/performancemonitor) - Lightweight menu bar system monitor: CPU, memory, network, disk, GPU, per-sensor temperatures, SSD wear, and battery health. No telemetry.
 - [Pi Stats](https://github.com/Bunn/PiStats) - macOS app to visualize Pi-hole information.
 
   **Languages:** <img src='./icons/swift-64.png' alt='Swift icon' title='Swift' height='16'/> Swift <img src='./icons/objective-c-64.png' alt='Objective-C icon' title='Objective-C' height='16'/> Objective-C 


### PR DESCRIPTION
Adds [Performance Monitor](https://github.com/inequitas/performancemonitor) — a free, MIT-licensed menu bar system monitor for Apple Silicon Macs, written in Swift/SwiftUI with zero third-party dependencies. CPU, memory, network, disk, GPU, per-sensor temperatures, SSD wear, and battery health; localized in 7 languages; no telemetry. Inserted alphabetically; section count updated.