### PR TITLE
Add Mojito

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,25 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "Mojito",
+            "short_description": "Menu bar app that expands :emoji: shortcodes into emoji, symbols, and GIFs in any text field.",
+            "categories": [
+                "keyboard",
+                "menubar",
+                "productivity"
+            ],
+            "repo_url": "https://github.com/wr/mojito",
+            "icon_url": "https://mojito.wells.ee/app-icon-512.png",
+            "screenshots": [
+                "https://mojito.wells.ee/screenshot-imessage.png",
+                "https://mojito.wells.ee/screenshot-terminal.png"
+            ],
+            "official_site": "https://mojito.wells.ee",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Project URL
https://github.com/wr/mojito

## Category
keyboard, menubar, productivity

## Description
Mojito is a free menu bar utility that expands `:emoji:` shortcodes into real emoji in any macOS text field. Typing `:` opens a fuzzy-search picker next to the cursor; typing the closing colon inserts the exact match directly. It also converts emoticons like `:)`, offers hundreds of symbols (`::cmd::` for ⌘), and GIF search via `:::`. Everything runs on-device, it skips password fields, and apps with native emoji input (Slack, Discord, etc.) are excluded out of the box. AGPL-3.0, macOS 14+.

## Why it should be included to `Awesome macOS open source applications ` (optional)
Fills a gap the list doesn't cover: system-wide Slack-style emoji shortcodes. Actively maintained, localized into 18 languages.

## Checklist
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English