### PR TITLE
Add Pulse

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,6 +1,24 @@
 {
     "applications": [
 	{
+            "title": "Pulse",
+            "short_description": "Native macOS menu bar market tracker for stocks, cryptocurrencies, indices, ETFs, and portfolio P&L.",
+            "categories": [
+                "menubar",
+                "cryptocurrency"
+            ],
+            "repo_url": "https://github.com/fatwang2/Pulse",
+            "icon_url": "https://raw.githubusercontent.com/fatwang2/Pulse/main/PulseMac/Resources/Assets.xcassets/AppIcon.appiconset/icon_512x512.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/fatwang2/Pulse/main/website/public/og-v2.png",
+                "https://raw.githubusercontent.com/fatwang2/Pulse/main/assets/readme/pulse-watchlist-share.png"
+            ],
+            "official_site": "https://www.pulseticker.app/",
+            "languages": [
+                "swift"
+            ]
+        },
+	{
             "title": "ActivityWatch",
             "short_description": "Open-source automated time tracker that tracks how you spend time on your devices.",
             "categories": [


### PR DESCRIPTION
## Project URL

https://github.com/fatwang2/Pulse

## Category

menubar, cryptocurrency

## Description

Pulse is a native SwiftUI macOS menu bar market tracker for stocks, cryptocurrencies, indices, ETFs, watchlists, and portfolio P&L.

## Why it should be included to `Awesome macOS open source applications`

Pulse is an actively maintained, MIT-licensed Swift app with a current downloadable release, a clear English README, an official website, and public icon and screenshot assets.

## Checklist

- [x] Edited `applications.json` instead of `README.md`
- [x] Only one project/change is in this pull request
- [x] Screenshots added
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English

Disclosure: I am the developer of Pulse.
