### PR TITLE
Add Tameo (clipboard manager with on-device OCR search)

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -5648,6 +5648,22 @@
             ]
         },
         {
+            "short_description": "Privacy-first clipboard manager with history search, on-device image OCR, and snippets.",
+            "categories": [
+                "productivity"
+            ],
+            "repo_url": "https://github.com/supergodak/tameo",
+            "title": "Tameo",
+            "icon_url": "",
+            "screenshots": [
+                "https://raw.githubusercontent.com/supergodak/tameo/main/docs/images/palette.png"
+            ],
+            "official_site": "https://tameo.ati-mirai.co.jp",
+            "languages": [
+                "swift"
+            ]
+        },
+        {
             "short_description": "macOS open source clipboard manager",
             "categories": [
                 "productivity"


### PR DESCRIPTION
## Project URL
https://github.com/supergodak/tameo

## Category
productivity

## Description
Tameo is a free, MIT-licensed clipboard manager for macOS (Apple-Silicon-native, SwiftUI). It keeps a searchable clipboard history — search folds Japanese kana/width variants — and runs on-device OCR on copied images and screenshots, so you can find and paste the text inside them. It also supports snippets (with Clipy import), per-type storage filters, and excluded apps. Fully local: no telemetry, analytics, or servers; password-manager items (ConcealedType) are never stored. Distributed as a notarized, Developer-ID-signed DMG with Sparkle auto-updates, plus a Homebrew cask.

## Why it should be included to `Awesome macOS open source applications ` (optional)
It is, to our knowledge, the only free open-source macOS clipboard manager with built-in on-device image OCR search. Actively maintained (last release this month).

## Checklist
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English
