### PR TITLE
Add Mac Server Mode

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,6 +1,21 @@
 {
     "applications": [
 	{
+            "title": "Mac Server Mode",
+            "short_description": "Keep Mac Mini servers awake with display turned off.",
+            "categories": [
+                "utilities",
+                "menubar"
+            ],
+            "repo_url": "https://github.com/thairc-dev/mac-server-mode",
+            "icon_url": "",
+            "screenshots": [],
+            "official_site": "https://github.com/thairc-dev/mac-server-mode",
+            "languages": [
+                "swift"
+            ]
+        },
+	{
             "title": "ActivityWatch",
             "short_description": "Open-source automated time tracker that tracks how you spend time on your devices.",
             "categories": [


### PR DESCRIPTION
Add Mac Server Mode under utilities and menubar categories. It is a lightweight macOS Menu Bar app written in native Swift to keep Mac Mini servers awake with display turned off.