### PR TITLE
Add Logue

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,5 +1,25 @@
 {
     "applications": [
+        {
+            "title": "Logue",
+            "short_description": "Privacy-first AI meeting notes and writing assistant with on-device transcription, smart minutes, action items, and 60+ writing modes — runs entirely on Apple Silicon.",
+            "categories": [
+                "notes",
+                "productivity"
+            ],
+            "repo_url": "https://github.com/bitwize-ai/Logue",
+            "icon_url": "https://raw.githubusercontent.com/bitwize-ai/Logue/main/Logue/Assets.xcassets/AppIcon.appiconset/icon_512x512.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/bitwize-ai/Logue/main/docs/images/home-dashboard.png",
+                "https://raw.githubusercontent.com/bitwize-ai/Logue/main/docs/images/meeting-transcription.png",
+                "https://raw.githubusercontent.com/bitwize-ai/Logue/main/docs/images/smart-minutes.png",
+                "https://raw.githubusercontent.com/bitwize-ai/Logue/main/docs/images/writing-editor.png"
+            ],
+            "official_site": "https://github.com/bitwize-ai/Logue",
+            "languages": [
+                "swift"
+            ]
+        },
 	{
             "title": "ActivityWatch",
             "short_description": "Open-source automated time tracker that tracks how you spend time on your devices.",


### PR DESCRIPTION
## Project URL
https://github.com/bitwize-ai/Logue

## Category
notes, productivity

## Description
Logue is a privacy-first AI meeting notes and writing assistant for macOS (Tahoe / macOS 26+). All AI inference, transcription, and data processing run locally on-device via Apple's MLX framework on Apple Silicon — by default nothing leaves the laptop. It provides real-time meeting transcription with speaker diarization, AI-generated smart minutes and action items, on-device PII detection, and 60+ writing modes for document editing. MIT licensed.

## Why it should be included to `Awesome macOS open source applications ` (optional)
It's a fully open-source, native SwiftUI macOS app with a clear focus on on-device privacy, actively maintained, and offers a category of functionality (local AI meeting notes) not currently represented in the list.

## Checklist
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)