### PR TITLE
Add Rekody

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,6 +1,23 @@
 {
     "applications": [
 	{
+            "title": "Rekody",
+            "short_description": "Voice dictation CLI for macOS: hold a hotkey, speak, and on-device transcription types the text at the cursor in any app.",
+            "categories": [
+                "audio",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/rekody/rekody",
+            "icon_url": "https://raw.githubusercontent.com/rekody/rekody/main/website/public/icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/rekody/rekody/main/docs/assets/cli-streaming.png"
+            ],
+            "official_site": "",
+            "languages": [
+                "rust"
+            ]
+        },
+	{
             "title": "ActivityWatch",
             "short_description": "Open-source automated time tracker that tracks how you spend time on your devices.",
             "categories": [


### PR DESCRIPTION
## Project URL
https://github.com/rekody/rekody

## Category
audio, utilities

## Description
Rekody is a voice dictation CLI for macOS, written in Rust (MIT). Hold a hotkey, speak, and on-device transcription types the text at the cursor in any app. It supports a personal dictionary for names and jargon. The CLI and engine at the linked repo are fully open source; to be transparent, the companion menu-bar GUI app is distributed separately as freeware and is not open source, so this entry covers the CLI only and the description says so explicitly.

## Why it should be included to `Awesome macOS open source applications ` (optional)
There is currently no voice dictation tool on the list. Rekody is actively maintained (latest release v0.5.23, July 2026) with a clear English README, and terminal tools have precedent here (micro, Dnote, Watson, fselect).

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
