### PR TITLE
Add Preview3MF

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,6 +1,22 @@
 {
     "applications": [
 	{
+            "title": "Preview3MF",
+            "short_description": "Quick Look extension that shows a 3D preview and Finder thumbnails for .3mf 3D-printing files.",
+            "categories": [
+                "finder"
+            ],
+            "repo_url": "https://github.com/cavoco/Preview3MF",
+            "icon_url": "",
+            "screenshots": [
+                "https://raw.githubusercontent.com/cavoco/Preview3MF/main/docs/preview.png"
+            ],
+            "official_site": "https://cavoco.github.io/Preview3MF/",
+            "languages": [
+                "swift"
+            ]
+        },
+	{
             "title": "ActivityWatch",
             "short_description": "Open-source automated time tracker that tracks how you spend time on your devices.",
             "categories": [


### PR DESCRIPTION
Adds [Preview3MF](https://github.com/cavoco/Preview3MF) under the **Finder** category.

A free, open-source (MIT) macOS Quick Look extension for `.3mf` 3D-printing files — press Space in Finder to get a 3D preview of the model, plus rendered Finder thumbnails. Universal (Apple Silicon + Intel), signed and notarized, macOS 13+.

Edited `applications.json` per the contribution guidelines.