### PR TITLE
Add Viaduct-CLI

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,22 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "Viaduct-CLI",
+            "short_description": "Command-line tool that converts a Google Chrome extension into a Safari web extension.",
+            "categories": [
+                "browser",
+                "extensions"
+            ],
+            "repo_url": "https://github.com/magicelk235/Viaduct-CLI",
+            "icon_url": "https://raw.githubusercontent.com/magicelk235/Viaduct-app/main/icon.png",
+            "screenshots": [],
+            "official_site": "https://magicelklabs.com",
+            "languages": [
+                "typescript",
+                "javascript"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Adds Viaduct-CLI, a command-line tool that converts a Google Chrome extension into a Safari web extension.

- Repo: https://github.com/magicelk235/Viaduct-CLI
- License: MIT
- Written in TypeScript/JavaScript

It handles the manifest conversion, shims Chrome APIs that Safari doesn't support, and packages the result as a Safari web extension. Follows the contributing format: single entry in applications.json, categorized under browser and extensions.