### PR TITLE
Add DevProjex

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,20 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "DevProjex",
+            "short_description": "Cross-platform GUI and CLI for building structured project context with folder trees, file contents, token counting, Smart Ignore, preview, and multi-format export.",
+            "categories": [
+                "development"
+            ],
+            "repo_url": "https://github.com/Avazbek22/DevProjex",
+            "icon_url": "",
+            "screenshots": [],
+            "official_site": "https://github.com/Avazbek22/DevProjex",
+            "languages": [
+                "c_sharp"
+            ]
         }
     ]
 }

--- a/applications.json
+++ b/applications.json
@@ -11085,7 +11085,7 @@
         },
         {
             "title": "DevProjex",
-            "short_description": "Cross-platform GUI and CLI for building structured project context with folder trees, file contents, token counting, Smart Ignore, preview, and multi-format export.",
+            "short_description": "Cross-platform macOS codebase-context app for Intel and Apple Silicon, with GUI, TUI, CLI, live preview, redaction, and a built-in read-only MCP server.",
             "categories": [
                 "development"
             ],


### PR DESCRIPTION
## Project URL
https://github.com/Avazbek22/DevProjex

## Category
development

## Description
Cross-platform macOS codebase-context app for Intel and Apple Silicon, with GUI, TUI, CLI, live preview, redaction, and a built-in read-only MCP server.

## Why it should be included to Awesome macOS open source applications (optional)
DevProjex is an open-source developer utility with current macOS releases for Intel and Apple Silicon.

## Checklist
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English