### PR TITLE
Add Doppel - native duplicate file finder for macOS

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,6 +1,21 @@
 {
     "applications": [
 	{
+            "title": "Doppel",
+            "short_description": "Native duplicate file finder for macOS that matches files by content hash (not filename), with Trash-based deletion and Quick Look preview.",
+            "categories": [
+                "system",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/JerzyD72/Doppel",
+            "icon_url": "https://raw.githubusercontent.com/JerzyD72/Doppel/main/Assets/icon_1024.png",
+            "screenshots": [],
+            "official_site": "https://github.com/JerzyD72/Doppel",
+            "languages": [
+                "swift"
+            ]
+        },
+	{
             "title": "ActivityWatch",
             "short_description": "Open-source automated time tracker that tracks how you spend time on your devices.",
             "categories": [


### PR DESCRIPTION
Adds [Doppel](https://github.com/JerzyD72/Doppel), a free, open-source (MIT), native SwiftUI app for finding duplicate files on macOS.

- Matches duplicates by content (size + sampled SHA-256 hash), never by filename
- Filter by file type, Quick Look preview before deleting
- Deletion always goes to the Trash, never permanent
- Hard-excludes /System, /private, /usr, /bin, /sbin, and Xcode Simulator data from every scan
- No third-party dependencies
- English and Polish UI

Categories: System, Utilities.