### PR TITLE
Add Qwen Scribe

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,26 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "Qwen Scribe",
+            "short_description": "Private, local transcription and system-wide dictation for Apple Silicon, powered by Qwen3-ASR on MLX.",
+            "categories": [
+                "audio",
+                "productivity",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/VladUZH/qwen-scribe",
+            "icon_url": "https://raw.githubusercontent.com/VladUZH/qwen-scribe/main/assets/AppIcon-1024.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/VladUZH/qwen-scribe/main/docs/assets/hero.png",
+                "https://raw.githubusercontent.com/VladUZH/qwen-scribe/main/docs/assets/dictation-states.png"
+            ],
+            "official_site": "https://github.com/VladUZH/qwen-scribe",
+            "languages": [
+                "python",
+                "objective_c"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Adds [Qwen Scribe](https://github.com/VladUZH/qwen-scribe) to `applications.json`.

Qwen Scribe is an Apache-2.0 macOS app for private, fully local speech-to-text
on Apple Silicon. It runs Qwen3-ASR on the Mac's Metal GPU through MLX, with no
account, API key, or cloud service — audio and transcripts stay on the machine.

Two ways to use it:

- Drag-and-drop audio/video transcription in a local web interface, with
  language detection, vocabulary hints, word timestamps, and SRT export.
- System-wide dictation — hold right Command in any text field, speak, release,
  and the transcription is pasted at the cursor.

Categories: `audio`, `productivity`, `utilities`. Languages: `python`,
`objective_c` (the dictation helper is a native Objective-C bundle executable).

Disclosure: I am the author of the project.

- [x] Searched for duplicates
- [x] Individual PR for a single suggestion
- [x] Edited `applications.json`, not `README.md`
- [x] Existing categories and language identifiers used
- [x] Description is short and ends with a period
- [x] Icon and screenshot URLs verified reachable
- [x] No trailing whitespace
