### PR TITLE
Add ClaudeNotch to Menubar section

### DIFF
--- a/README.md
+++ b/README.md
@@ -4357,7 +4357,7 @@ You can see in which language an app is written. Currently there are following l
   </p>
   </details>
 
-### 📊 Menubar (52)
+### 📊 Menubar (53)
 - [Airpass](https://github.com/alvesjtiago/airpass) - Status bar Mac application to overcome time constrained WiFi networks. 
 
   **Languages:** <img src='./icons/javascript-64.png' alt='JavaScript icon' title='JavaScript' height='16'/> JavaScript 
@@ -4435,6 +4435,19 @@ You can see in which language an app is written. Currently there are following l
   <p>
 
   <img src='https://github.com/user-attachments/assets/63dade24-d967-4946-89e5-f8ae44097b31' width='400' loading='lazy' decoding='async' fetchpriority='low'/>
+
+  </p>
+  </details>
+
+- [ClaudeNotch](https://github.com/hidrogenone/ClaudeNotch) - Drops the MacBook notch down with a Dynamic-Island-style alert when Claude (status.claude.com) has an incident.
+
+  **Languages:** <img src='./icons/swift-64.png' alt='Swift icon' title='Swift' height='16'/> Swift 
+
+  <details>
+  <summary>Screenshots</summary>
+  <p>
+
+  <img src='https://raw.githubusercontent.com/hidrogenone/ClaudeNotch/main/docs/screenshot.png' width='400' loading='lazy' decoding='async' fetchpriority='low'/>
 
   </p>
   </details>


### PR DESCRIPTION
Adds **[ClaudeNotch](https://github.com/hidrogenone/ClaudeNotch)** — a native Swift/SwiftUI menu bar app that drops the MacBook notch down with a Dynamic-Island-style alert (plus a red screen-edge flash) when Claude (status.claude.com) publishes an incident. Hovering the notch shows live per-component health.

- MIT licensed, pure Swift/SwiftUI + AppKit, no dependencies
- Placed alphabetically in the Menubar section, count bumped 52 → 53
- Screenshot included from the app repo