### PR TITLE
Add CrossGen

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,5 +1,25 @@
 {
     "applications": [
+        {
+            "title": "CrossGen",
+            "short_description": "Local-first AI image workspace for generating, editing, organizing, and reusing images through a desktop app, JSON CLI, and MCP-compatible agents.",
+            "categories": [
+                "graphics",
+                "images",
+                "productivity"
+            ],
+            "repo_url": "https://github.com/Bliveren/CrossGen",
+            "icon_url": "https://raw.githubusercontent.com/Bliveren/CrossGen/main/build/icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/Bliveren/CrossGen/main/docs/assets/screenshot-workspace.png",
+                "https://raw.githubusercontent.com/Bliveren/CrossGen/main/docs/assets/screenshot-edit.png"
+            ],
+            "official_site": "https://www.corgnitor.com/products/crossgen",
+            "languages": [
+                "typescript",
+                "javascript"
+            ]
+        },
 	{
             "title": "ActivityWatch",
             "short_description": "Open-source automated time tracker that tracks how you spend time on your devices.",


### PR DESCRIPTION
## Project URL
https://github.com/Bliveren/CrossGen

## Category
graphics, images, productivity

## Description
CrossGen is a local-first AI image workspace for generating, editing, organizing, and reusing images through a desktop app, JSON CLI, and MCP-compatible agents.

## Why it should be included to `Awesome macOS open source applications`
CrossGen is a working cross-platform Electron desktop app with a notarized macOS arm64 release. Its v0.3.1 release adds a packaged JSON CLI and local MCP stdio server while keeping image workflows and assets local.

Disclosure: I maintain CrossGen.

## Checklist
- [x] Edited `applications.json` instead of `README.md`
- [x] Only one project/change is in this pull request
- [x] Screenshots added
- [x] Has a commit from less than 2 years ago
- [x] Has a clear README in English
- [x] Icon and screenshot URLs return HTTP 200
- [x] Description is short and ends with a period

Note: the upstream `applications.json` is not strict JSON before this PR; this change preserves the existing file structure and introduces no whitespace errors.