### PR TITLE
Add ItsPaint, and fix the trailing commas that break applications.json

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -166,7 +166,7 @@
         {
             "short_description": "Fun Tic Tac Toe game equipped with multiplayer (local and online) and leveled single player available on the App Store.",
             "categories": [
-                "games",
+                "games"
             ],
             "repo_url": "https://github.com/Aries-Sciences-LLC/Tic-Tac-Toe",
             "title": "Amazing Tic Tac Toe",
@@ -184,7 +184,7 @@
         {
             "short_description": "Simple and elegant menubar weather app on the App Store.",
             "categories": [
-                "menubar",
+                "menubar"
             ],
             "repo_url": "https://github.com/Aries-Sciences-LLC/Quick-Weather",
             "title": "Quick Weather",
@@ -11066,6 +11066,22 @@
             "official_site": "https://gramps-project.org",
             "languages": [
                 "python"
+            ]
+        },
+        {
+            "title": "ItsPaint",
+            "short_description": "Focused paint and screenshot markup app. Step badges, pixelate redaction, Instant Alpha. No account, no telemetry.",
+            "categories": [
+                "graphics"
+            ],
+            "repo_url": "https://github.com/joshlin2201/itspaint",
+            "icon_url": "https://raw.githubusercontent.com/joshlin2201/itspaint/main/App/Resources/Assets.xcassets/AppIcon.appiconset/icon_256x256.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/joshlin2201/itspaint/main/docs/images/editor-window.png"
+            ],
+            "official_site": "https://sites.fynesite.com/itspaint/",
+            "languages": [
+                "swift"
             ]
         },
         {


### PR DESCRIPTION
Two changes, one mechanical:

1. **Fixes `applications.json`**: two illegal trailing commas (inside the `categories` arrays of Amazing Tic Tac Toe and Quick Weather) currently make the file invalid JSON, so every parser and tool consuming it fails. Removed both; the file now round-trips through `json.loads`.

2. **Adds ItsPaint** (graphics): a free, MIT-licensed native macOS paint and screenshot-markup app. AppKit + SwiftUI, zero third-party dependencies, signed and notarised releases, universal binary, macOS 14+. Step badges, pixelate redaction, Instant Alpha, real transparency, eight export formats. No account, no telemetry, no network code.

   - Source: https://github.com/joshlin2201/itspaint
   - Homepage: https://sites.fynesite.com/itspaint/

I am the developer. Edited `applications.json` only, per the contribution guidance; the README is generated.