### PR TITLE
Add Phosphene

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,24 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "Phosphene",
+            "short_description": "Use any video as your macOS wallpaper on the desktop and the lock screen, picked directly from System Settings.",
+            "categories": [
+                "wallpaper",
+                "menubar"
+            ],
+            "repo_url": "https://github.com/kageroumado/phosphene",
+            "icon_url": "https://raw.githubusercontent.com/kageroumado/phosphene/main/.github/phosphene-icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/kageroumado/phosphene/main/.github/phosphene-library.png",
+                "https://raw.githubusercontent.com/kageroumado/phosphene/main/.github/phosphene-popover.png"
+            ],
+            "official_site": "https://kagerou.glass/phosphene/",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Adds **Phosphene** to applications.json.

Use any video as your macOS wallpaper on the desktop and the lock screen, picked directly from System Settings.

MIT-licensed, actively maintained (last commit July 2026), builds on current Xcode, English README. Disclosure: I'm the developer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012R4qcu8ZgzDsEx4oRDF4RE