### PR TITLE
Add Adrafinil

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,24 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "Adrafinil",
+            "short_description": "Keeps your Mac awake only while AI agents are working, then lets it sleep normally.",
+            "categories": [
+                "menubar",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/kageroumado/adrafinil",
+            "icon_url": "https://raw.githubusercontent.com/kageroumado/adrafinil/main/.github/adrafinil-icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/kageroumado/adrafinil/main/.github/adrafinil-awake.png",
+                "https://raw.githubusercontent.com/kageroumado/adrafinil/main/.github/adrafinil-sleeping.png"
+            ],
+            "official_site": "https://kagerou.glass/adrafinil/",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Adds **Adrafinil** to applications.json.

Keeps your Mac awake only while AI agents are working, then lets it sleep normally.

MIT-licensed, actively maintained (last commit July 2026), builds on current Xcode, English README. Disclosure: I'm the developer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012R4qcu8ZgzDsEx4oRDF4RE