### PR TITLE
Add Dantrolene

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,24 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "Dantrolene",
+            "short_description": "Stops the screen from locking while on your home WiFi; locks normally on every other network.",
+            "categories": [
+                "menubar",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/kageroumado/dantrolene",
+            "icon_url": "https://raw.githubusercontent.com/kageroumado/dantrolene/main/.github/dantrolene-icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/kageroumado/dantrolene/main/.github/dantrolene-home.png",
+                "https://raw.githubusercontent.com/kageroumado/dantrolene/main/.github/dantrolene-away.png"
+            ],
+            "official_site": "https://kagerou.glass/dantrolene/",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Adds **Dantrolene** to applications.json.

Stops the screen from locking while on your home WiFi; locks normally on every other network.

MIT-licensed, actively maintained (last commit July 2026), builds on current Xcode, English README. Disclosure: I'm the developer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012R4qcu8ZgzDsEx4oRDF4RE