### PR TITLE
Add Rilmazafone

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,24 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "Rilmazafone",
+            "short_description": "Design DMG installers on a WYSIWYG canvas and build exactly what you drew.",
+            "categories": [
+                "development",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/kageroumado/rilmazafone",
+            "icon_url": "https://raw.githubusercontent.com/kageroumado/rilmazafone/main/.github/rilmazafone-icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/kageroumado/rilmazafone/main/screenshot.png",
+                "https://raw.githubusercontent.com/kageroumado/rilmazafone/main/.github/rilmazafone-templates.png"
+            ],
+            "official_site": "https://kagerou.glass/rilmazafone/",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Adds **Rilmazafone** to applications.json.

Design DMG installers on a WYSIWYG canvas and build exactly what you drew.

MIT-licensed, actively maintained (last commit July 2026), builds on current Xcode, English README. Disclosure: I'm the developer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012R4qcu8ZgzDsEx4oRDF4RE