### PR TITLE
Add Coluracetam

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,23 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "Coluracetam",
+            "short_description": "Markdown reader with Quick Look and thumbnail extensions, so .md files render on spacebar and in Finder.",
+            "categories": [
+                "markdown"
+            ],
+            "repo_url": "https://github.com/kageroumado/coluracetam",
+            "icon_url": "https://raw.githubusercontent.com/kageroumado/coluracetam/main/.github/coluracetam-icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/kageroumado/coluracetam/main/.github/coluracetam-rendered.png",
+                "https://raw.githubusercontent.com/kageroumado/coluracetam/main/.github/coluracetam-split.png"
+            ],
+            "official_site": "https://kagerou.glass/coluracetam/",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Adds **Coluracetam** to applications.json.

Markdown reader with Quick Look and thumbnail extensions, so .md files render on spacebar and in Finder.

MIT-licensed, actively maintained (last commit July 2026), builds on current Xcode, English README. Disclosure: I'm the developer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012R4qcu8ZgzDsEx4oRDF4RE