### PR TITLE
Add QuotaBar

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11069,6 +11069,26 @@
             ]
         },
         {
+            "title": "QuotaBar",
+            "short_description": "Local-first macOS menu bar app for tracking OpenAI Codex usage limits, reset countdowns, and optional alerts.",
+            "categories": [
+                "utilities",
+                "menubar",
+                "development"
+            ],
+            "repo_url": "https://github.com/RoketrP/QuotaBar",
+            "icon_url": "https://raw.githubusercontent.com/RoketrP/QuotaBar/main/docs/assets/quotabar-icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/RoketrP/QuotaBar/main/docs/assets/quotabar-social-card.png",
+                "https://raw.githubusercontent.com/RoketrP/QuotaBar/main/docs/assets/quotabar-dashboard.png",
+                "https://raw.githubusercontent.com/RoketrP/QuotaBar/main/docs/assets/quotabar-hud-v1.1.png"
+            ],
+            "official_site": "https://roketrp.github.io/QuotaBar/",
+            "languages": [
+                "swift"
+            ]
+        },
+        {
             "title": "MacNTop",
             "short_description": "macOS menu bar system monitor with retro CRT aesthetics.",
             "categories": [


### PR DESCRIPTION
Adds QuotaBar to `applications.json`.

QuotaBar is a free, MIT-licensed, local-first macOS menu bar utility for tracking OpenAI Codex 5-hour and weekly limits, reset countdowns, a compact floating HUD, and optional alerts.

- Repository: https://github.com/RoketrP/QuotaBar
- Website: https://roketrp.github.io/QuotaBar/
- Latest release: https://github.com/RoketrP/QuotaBar/releases/tag/v1.1.0

The entry uses existing category IDs (`utilities`, `menubar`, and `development`), a one-sentence description ending in a period, Swift as the language, and publicly reachable icon/screenshot URLs. All listed asset URLs returned HTTP 200 during validation.
