### PR TITLE
Add Petrichor - offline music player for macOS

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,23 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "Petrichor",
+            "short_description": "Offline music player for macOS with library management, smart playlists, synced lyrics and an equalizer.",
+            "categories": [
+                "audio",
+                "music"
+            ],
+            "repo_url": "https://github.com/kushalpandya/Petrichor",
+            "icon_url": "https://raw.githubusercontent.com/kushalpandya/Petrichor/main/.github/assets/DefaultAppIcon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/kushalpandya/Petrichor/main/.github/assets/hero_screenshot.png"
+            ],
+            "official_site": "https://petrichor.page",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Project URL
https://github.com/kushalpandya/Petrichor

## Category
audio, music

## Description

Petrichor is a free and open-source offline music player for macOS (14+, Apple Silicon and Intel). It maps your local music folders into an organized library and supports over 20 audio formats (MP3, AAC/M4A, ALAC, WAV, AIFF, FLAC, Ogg Vorbis, Opus, Speex, APE, MPC, TTA, WavPack, DSF/DFF and more).

Features include smart playlists with conditional rules, M3U playlist import/export, an interactive drag-and-drop play queue, folder view browsing, synced lyrics, an equalizer, gapless playback, a miniplayer and immersive mode, sidebar pinning, Last.fm scrobbling, and Shortcuts/Siri automation support. It integrates natively with the macOS menu bar and dock playback controls, is sandboxed and notarized, has no analytics, and keeps your library data offline.

## Why it should be included to `Awesome macOS open source applications `

The app has over 1500 stars on GitHub and over 22,000 downloads. :)

It is an actively maintained, MIT-licensed native SwiftUI music player built specifically for macOS, and complements the existing offline player entries in the audio/music categories. It is also distributed via Homebrew (`brew install --cask petrichor`).

## Checklist

- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English