### PR TITLE
Add Notchi

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,6 +1,26 @@
 {
     "applications": [
 	{
+            "title": "Notchi",
+            "short_description": "Turn the MacBook notch into a place to ask AI, save notes, set reminders, or run coding agents.",
+            "categories": [
+                "productivity",
+                "notes",
+                "menubar",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/cyrus-cai/notchi",
+            "icon_url": "https://raw.githubusercontent.com/cyrus-cai/notchi/master/.github/icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/cyrus-cai/notchi/master/.github/shots/verb-ask.jpg",
+                "https://raw.githubusercontent.com/cyrus-cai/notchi/master/.github/shots/agent-compose.jpg"
+            ],
+            "official_site": "https://www.notch.website/",
+            "languages": [
+                "swift"
+            ]
+        },
+	{
             "title": "ActivityWatch",
             "short_description": "Open-source automated time tracker that tracks how you spend time on your devices.",
             "categories": [


### PR DESCRIPTION
## Summary

Adds Notchi to the macOS app directory.

Notchi is an open-source native macOS app that turns the MacBook notch into a compact command bar for:

- Asking AI
- Capturing notes
- Creating reminders
- Running coding agents

This entry includes the official website, source repository, app icon, and product screenshots.

## Details

- Categories: Productivity, Notes, Menu Bar, Utilities
- Language: Swift
- License: MIT
- Website: https://www.notch.website/
- Source: https://github.com/cyrus-cai/notchi