### PR TITLE
Add Zielzeit

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,24 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "Zielzeit",
+            "short_description": "Menu bar app projecting the year your Scalable Capital portfolio reaches a savings goal, read-only through the official broker CLI.",
+            "categories": [
+                "menubar",
+                "productivity"
+            ],
+            "repo_url": "https://github.com/Mannafee/zielzeit-scalable-capital",
+            "icon_url": "https://raw.githubusercontent.com/Mannafee/zielzeit-scalable-capital/main/docs/icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/Mannafee/zielzeit-scalable-capital/main/docs/popover.png",
+                "https://raw.githubusercontent.com/Mannafee/zielzeit-scalable-capital/main/docs/menubar.png"
+            ],
+            "official_site": "https://mannafee.github.io/zielzeit-scalable-capital/",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Adding [Zielzeit](https://github.com/Mannafee/zielzeit-scalable-capital), an open-source macOS menu bar app for Scalable Capital investors. It answers one question — when will my portfolio reach my goal? — and keeps the projected year in the menu bar.

- Native SwiftUI/AppKit, Swift, macOS 15+, universal, MIT.
- Reads the account through Scalable Capital's own official CLI, read-only. No scraping, no unofficial API, no credentials, no networking code in the app.
- English and German.

Per the guidelines this edits `applications.json` rather than `README.md`, with `menubar` and `productivity` from `categories.json`, an icon and two screenshots.

One note in case it is useful: `applications.json` currently has trailing commas in a few category arrays (the oldest is line 169, `"games",`), so it does not parse as strict JSON. My entry does not add one and I have left the existing ones alone rather than widen this diff.

Disclosure: I am the author.