### PR TITLE
Add qwen-audio-agent — full-duplex voice interface for AI coding agents

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -17,6 +17,23 @@
             ]
         },
 	{
+		"short_description": "Full-duplex voice interface for AI coding agents. Talk to Claude Code, Codex, OpenCode and other ACP agents hands-free, with barge-in, spoken permission prompts, async task results read back, and a fully local wake word.",
+		"categories": [
+			"audio",
+			"development"
+		],
+		"repo_url": "https://github.com/QwenAudio/qwen-audio-agent",
+		"title": "qwen-audio-agent",
+		"icon_url": "https://raw.githubusercontent.com/QwenAudio/qwen-audio-agent/main/desktop/build/icon.png",
+		"screenshots": [
+			"https://raw.githubusercontent.com/QwenAudio/qwen-audio-agent/main/docs/desktop-fluid-orb-thinking.gif"
+		],
+		"official_site": "https://github.com/QwenAudio/qwen-audio-agent",
+		"languages": [
+			"javascript"
+		]
+	},
+	{
             "short_description": "Clipboard history manager for macOS with terminal-style navigation, image previews, and cursor-following popup.",
             "categories": [
                 "utilities",


### PR DESCRIPTION
## Project URL
https://github.com/QwenAudio/qwen-audio-agent

## Category
audio, development

## Description
qwen-audio-agent is an open-source, realtime full-duplex voice interface for AI coding agents. It connects to Claude Code, Codex, OpenCode, Kimi CLI and other agents over the Agent Client Protocol (ACP), so developers can work hands-free: interrupt the agent mid-answer (barge-in), approve permission prompts by voice, get async task results spoken back into the same conversation, and wake the session with a fully local wake word (sherpa-onnx keyword spotting, no cloud). Ships as an Electron desktop app for macOS (animated orb UI), plus a terminal TUI and web UI.

## Why it should be included to `Awesome macOS open source applications` (optional)
It's an actively maintained macOS audio + developer-tool app with a distinctive use of realtime voice tech (full-duplex conversation with coding agents, local wake word). Disclosure: I maintain this project.

## Checklist
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English