### PR TITLE
Add Eqlume

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -689,12 +689,12 @@
             "categories": [
                 "audio"
             ],
-            "repo_url": "https://github.com/gokturkgocen/Eqlume",
-            "title": "Eqlume",
-            "icon_url": "https://raw.githubusercontent.com/gokturkgocen/Eqlume/main/Resources/AppIcon-1024.png",
+            "repo_url": "https://github.com/gokturkgocen/EqLume",
+            "title": "EqLume",
+            "icon_url": "https://raw.githubusercontent.com/gokturkgocen/EqLume/main/Resources/AppIcon-1024.png",
             "screenshots": [
-                "https://raw.githubusercontent.com/gokturkgocen/Eqlume/main/assets/app-store/01-follows-your-music.png",
-                "https://raw.githubusercontent.com/gokturkgocen/Eqlume/main/assets/app-store/02-see-the-sound.png"
+                "https://raw.githubusercontent.com/gokturkgocen/EqLume/main/assets/app-store/01-follows-your-music.png",
+                "https://raw.githubusercontent.com/gokturkgocen/EqLume/main/assets/app-store/02-see-the-sound.png"
             ],
             "official_site": "https://apps.apple.com/app/id6793070613",
             "languages": [

--- a/applications.json
+++ b/applications.json
@@ -685,7 +685,7 @@
             ]
         },
         {
-            "short_description": "System-wide menu bar equalizer that detects each track's genre and applies a matching EQ preset automatically, using a Core Audio process tap (no virtual audio driver).",
+            "short_description": "System-wide equalizer that detects each track's genre and applies a matching preset automatically.",
             "categories": [
                 "audio"
             ],

--- a/applications.json
+++ b/applications.json
@@ -685,6 +685,23 @@
             ]
         },
         {
+            "short_description": "System-wide menu bar equalizer that detects each track's genre and applies a matching EQ preset automatically, using a Core Audio process tap (no virtual audio driver).",
+            "categories": [
+                "audio"
+            ],
+            "repo_url": "https://github.com/gokturkgocen/Eqlume",
+            "title": "Eqlume",
+            "icon_url": "https://raw.githubusercontent.com/gokturkgocen/Eqlume/main/Resources/AppIcon-1024.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/gokturkgocen/Eqlume/main/assets/app-store/01-follows-your-music.png",
+                "https://raw.githubusercontent.com/gokturkgocen/Eqlume/main/assets/app-store/02-see-the-sound.png"
+            ],
+            "official_site": "",
+            "languages": [
+                "swift"
+            ]
+        },
+        {
             "short_description": "System-Wide Equalizer for the Mac. ",
             "categories": [
                 "audio"

--- a/applications.json
+++ b/applications.json
@@ -696,7 +696,7 @@
                 "https://raw.githubusercontent.com/gokturkgocen/Eqlume/main/assets/app-store/01-follows-your-music.png",
                 "https://raw.githubusercontent.com/gokturkgocen/Eqlume/main/assets/app-store/02-see-the-sound.png"
             ],
-            "official_site": "",
+            "official_site": "https://apps.apple.com/app/id6793070613",
             "languages": [
                 "swift"
             ]


### PR DESCRIPTION
Adding [Eqlume](https://github.com/gokturkgocen/Eqlume) — an open-source (MIT) system-wide equalizer for macOS.

What makes it different from the equalizers already listed: instead of asking you to pick a preset, it detects the genre of each track as it plays (MusicBrainz → iTunes Search → an on-device CoreML classifier) and applies a matching EQ curve automatically.

- Captures system audio through a **Core Audio process tap** — no virtual audio driver and no kernel extension to install.
- Menu-bar only, native SwiftUI, runs entirely on-device.
- Per-output profiles (in-ear correction on the headphone jack, a desktop-speaker curve on opted-in outputs).

Edited `applications.json` (not the README) per the contribution guidelines, added under the `audio` category next to the other equalizers, one entry, no other changes.