### PR TITLE
Add TetherShot

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11,7 +11,7 @@
             "title": "TetherShot",
             "icon_url": "https://raw.githubusercontent.com/apoorvdarshan/TetherShot/main/Resources/AppIcon.png",
             "screenshots": [
-                "https://raw.githubusercontent.com/apoorvdarshan/TetherShot/main/Marketing/7a04fefc-c88f-43fe-9083-db13d0a5e4f8.jpg"
+                "https://tethershot.apoorvdarshan.com/assets/og-v106.jpg"
             ],
             "official_site": "https://tethershot.apoorvdarshan.com",
             "languages": [

--- a/applications.json
+++ b/applications.json
@@ -1,6 +1,24 @@
 {
     "applications": [
 	{
+            "short_description": "Capture pixel-perfect iPhone screenshots from the macOS menu bar over USB or Wi-Fi.",
+            "categories": [
+                "images",
+                "menubar",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/apoorvdarshan/TetherShot",
+            "title": "TetherShot",
+            "icon_url": "https://raw.githubusercontent.com/apoorvdarshan/TetherShot/main/Resources/AppIcon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/apoorvdarshan/TetherShot/main/Marketing/7a04fefc-c88f-43fe-9083-db13d0a5e4f8.jpg"
+            ],
+            "official_site": "https://tethershot.apoorvdarshan.com",
+            "languages": [
+                "swift"
+            ]
+        },
+	{
             "title": "ActivityWatch",
             "short_description": "Open-source automated time tracker that tracks how you spend time on your devices.",
             "categories": [


### PR DESCRIPTION
## Project URL
https://github.com/apoorvdarshan/TetherShot

## Category
images, menubar, utilities

## Description
TetherShot is a free, open-source macOS menu-bar utility for capturing pixel-perfect iPhone screenshots over USB or Wi-Fi. Captures save to a chosen folder and clipboard, with a global hotkey and optional per-device folders.

## Why it should be included in Awesome macOS open source applications
TetherShot is a native Swift, MIT-licensed utility with a clear English README, recent development, public screenshots, and no account, analytics, or server.

## Checklist
- [x] Edited `applications.json` instead of `README.md`.
- [x] Only one project/change is in this pull request.
- [x] Screenshot added.
- [x] Has a commit from less than 2 years ago.
- [x] Has a clear README in English.

## Validation
- Parsed `applications.json` with JSON5.
- Verified the repository, website, icon, and screenshot URLs return HTTP 200.
- Ran `git diff --check`.