### PR TITLE
Add Tracexy

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,21 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "Tracexy",
+            "short_description": "Native macOS network intelligence app that captures traffic and organizes it into explainable sessions.",
+            "categories": [
+                "system",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/RockxyApp/Tracexy",
+            "icon_url": "https://raw.githubusercontent.com/RockxyApp/Tracexy/main/Tracexy/Assets.xcassets/AppIcon.appiconset/128.png",
+            "screenshots": [],
+            "official_site": "https://github.com/RockxyApp/Tracexy",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }

--- a/applications.json
+++ b/applications.json
@@ -11092,8 +11092,11 @@
             ],
             "repo_url": "https://github.com/RockxyApp/Tracexy",
             "icon_url": "https://raw.githubusercontent.com/RockxyApp/Tracexy/main/Tracexy/Assets.xcassets/AppIcon.appiconset/128.png",
-            "screenshots": [],
-            "official_site": "https://github.com/RockxyApp/Tracexy",
+            "screenshots": [
+                "https://rockxy.io/assets/images/tracexy/Tracexy-Light.png?v=29fdd3db",
+                "https://rockxy.io/assets/images/tracexy/Tracexy-Dark.png?v=32a85865"
+            ],
+            "official_site": "https://rockxy.io/tracexy",
             "languages": [
                 "swift"
             ]

--- a/applications.json
+++ b/applications.json
@@ -11085,7 +11085,7 @@
         },
         {
             "title": "Tracexy",
-            "short_description": "Native macOS network intelligence app that captures traffic and organizes it into explainable sessions.",
+            "short_description": "Open-source PCAP and PCAPNG analyzer for macOS that groups live or saved traffic into app-aware sessions.",
             "categories": [
                 "system",
                 "utilities"

--- a/applications.json
+++ b/applications.json
@@ -11085,7 +11085,7 @@
         },
         {
             "title": "Tracexy",
-            "short_description": "Open-source PCAP and PCAPNG analyzer for macOS that groups live or saved traffic into app-aware sessions.",
+            "short_description": "Native, local-first network intelligence for macOS that turns live traffic and saved PCAP or PCAPNG captures into app-aware sessions.",
             "categories": [
                 "system",
                 "utilities"


### PR DESCRIPTION
## Project URL
https://github.com/RockxyApp/Tracexy

## Category
system, utilities

## Description
Native, local-first network intelligence for macOS that turns live traffic and saved PCAP or PCAPNG captures into app-aware sessions.

## Why it should be included to `Awesome macOS open source applications`
Tracexy is an actively developed, open-source Swift macOS application for investigating network conversations locally. It complements the network tools already listed here with a session-first workflow for exploring hosts, processes, protocols, timing, and packet evidence through a native SwiftUI/AppKit interface. The project has a public product website, current screenshots, a signed and notarized macOS release, and an AGPL-3.0-or-later source repository.

## Checklist
- [x] Edit `applications.json` instead of `README.md`.
- [x] Only one project/change is in this pull request.
- [x] Screenshots are included.
- [x] Has a commit from less than 2 years ago.
- [x] Has a clear README in English.