### PR TITLE
Add Shieldxy

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,22 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "Shieldxy",
+            "short_description": "Open-source, auditable application firewall for macOS that shows and controls outbound connections by signed app, domain, and policy.",
+            "categories": [
+                "security",
+                "system",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/RockxyApp/Shieldxy",
+            "icon_url": "https://raw.githubusercontent.com/RockxyApp/Shieldxy/main/Shieldxy/Assets.xcassets/AppIcon.appiconset/icon_128x128%402x.png",
+            "screenshots": [],
+            "official_site": "https://rockxy.io/shieldxy",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }

--- a/applications.json
+++ b/applications.json
@@ -11085,7 +11085,7 @@
         },
         {
             "title": "Shieldxy",
-            "short_description": "Open-source, auditable application firewall for macOS that shows and controls outbound connections by signed app, domain, and policy.",
+            "short_description": "Open-source, native macOS application firewall that monitors and controls outbound connections by app, domain, and policy.",
             "categories": [
                 "security",
                 "system",


### PR DESCRIPTION
## What changed

- Add Shieldxy to `applications.json`.
- Categorize it under Security, System, and Utilities.
- Include its official repository, icon, website, and Swift language metadata.

## Why

Shieldxy is an open-source, native macOS application firewall that monitors and controls outbound connections by app, domain, and policy.

## Validation

- Verified the repository, icon, and official website links return HTTP 200.
- Ran `git diff --check`.
- Confirmed the Shieldxy catalog object and required fields.
