### PR TITLE
Add Plonk — menu bar window manager with drawn snap zones and an MCP server

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,23 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "Plonk",
+            "short_description": "Menu bar window manager: snap zones you draw yourself, workspaces that reopen your apps on the right monitor, and an MCP server so an AI agent can arrange windows too.",
+            "categories": [
+                "window-management",
+                "menubar"
+            ],
+            "repo_url": "https://github.com/ostapondo/plonk",
+            "icon_url": "https://raw.githubusercontent.com/ostapondo/plonk/main/docs/logo-400.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/ostapondo/plonk/main/docs/demo.gif"
+            ],
+            "official_site": "https://ostapondo.github.io/Plonk/",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }

--- a/applications.json
+++ b/applications.json
@@ -11091,10 +11091,11 @@
                 "menubar",
                 "utilities"
             ],
-            "repo_url": "https://github.com/ostapondo/plonk",
-            "icon_url": "https://raw.githubusercontent.com/ostapondo/plonk/main/docs/logo-400.png",
+            "repo_url": "https://github.com/ostapondo/Plonk",
+            "icon_url": "https://raw.githubusercontent.com/ostapondo/Plonk/main/docs/logo-400.png",
             "screenshots": [
-                "https://raw.githubusercontent.com/ostapondo/plonk/main/docs/demo.gif"
+                "https://raw.githubusercontent.com/ostapondo/Plonk/main/docs/demo.gif",
+                "https://raw.githubusercontent.com/ostapondo/Plonk/main/docs/app-zones.png"
             ],
             "official_site": "https://ostapondo.github.io/Plonk/",
             "languages": [

--- a/applications.json
+++ b/applications.json
@@ -11085,10 +11085,11 @@
         },
         {
             "title": "Plonk",
-            "short_description": "Menu bar window manager: snap zones you draw yourself, workspaces that reopen your apps on the right monitor, and an MCP server so an AI agent can arrange windows too.",
+            "short_description": "Ten menu bar utilities in one app: a window manager with snap zones you draw yourself, workspaces that reopen your apps on the right monitor, on-device OCR, keep-awake, screenshot annotation, pointer tools and a shortcut guide. An AI agent can drive all of it over MCP.",
             "categories": [
                 "window-management",
-                "menubar"
+                "menubar",
+                "utilities"
             ],
             "repo_url": "https://github.com/ostapondo/plonk",
             "icon_url": "https://raw.githubusercontent.com/ostapondo/plonk/main/docs/logo-400.png",


### PR DESCRIPTION
## Project URL
https://github.com/ostapondo/plonk

## Category
window-management, menubar

## Description
Plonk is a macOS menu bar window manager. You draw the zone layout yourself — any number of zones, any size, a different set per monitor — and fill it by dragging a window in, by pressing ⌃⌥1–9, or by describing it to an AI agent: it ships an MCP server, so an agent can place every window on every monitor in one call. Workspaces remember the apps, each window's frame and the display it belonged to, and relaunch the lot onto an empty desktop. Also on board: on-device OCR of any screen region, pinned live crops, annotated screenshots, and keep-awake that ends when a process exits.

Swift, no third-party dependencies, MIT. Everything runs locally — the API binds to loopback and refuses requests carrying browser headers; the only outbound call is an update check that can be switched off.

## Why it should be included to `Awesome macOS open source applications ` (optional)
The list has Rectangle, Loop, Phoenix and Amethyst under Window Management; Plonk sits next to them but adds two things none of them have — user-drawn irregular zone sets with per-monitor assignment, and an MCP interface so an assistant can arrange the desk. It is open source (MIT), builds with `swift build`, and ships signed releases with GitHub build attestations.

## Checklist
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added if any