### PR TITLE
Add Nocturne

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,6 +1,23 @@
 {
     "applications": [
 	{
+            "title": "Nocturne",
+            "short_description": "Makes the menu bar clock unreadable so it stops telling you how late it is, without hiding anything or asking for permissions.",
+            "categories": [
+                "menubar",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/dotcomjack/nocturne",
+            "icon_url": "",
+            "screenshots": [
+                "https://raw.githubusercontent.com/dotcomjack/nocturne/main/docs/clock-before-after.png"
+            ],
+            "official_site": "",
+            "languages": [
+                "swift"
+            ]
+        },
+	{
             "title": "ActivityWatch",
             "short_description": "Open-source automated time tracker that tracks how you spend time on your devices.",
             "categories": [


### PR DESCRIPTION
Adding [Nocturne](https://github.com/dotcomjack/nocturne), an MIT-licensed native macOS menu bar app.

The menu bar clock is the one menu bar item macOS ships no visibility toggle for, so Nocturne makes it unreadable rather than hidden: it flips `com.apple.menuextra.clock IsAnalog`, swapping the digital readout for a small analog dial. Handy when glancing at the time derails a late night session.

- One Apple preference key, no private APIs, no Accessibility or Screen Recording permissions
- Native Swift and SwiftUI, no dependencies
- Restores the clock on quit, including on SIGTERM

Edited `applications.json` rather than `README.md`, per CONTRIBUTING.md, and added the entry at the top of the array following the existing convention. Categories: menubar, utilities.