### PR TITLE
Add Llamaport

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,24 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "Llamaport",
+            "short_description": "Run local GGUF models with llama-server. Reads model headers directly for real quantisation and context length, shows the full launch command before starting, reports live token rates and memory pressure, and downloads models from Hugging Face with resume that survives a kill.",
+            "categories": [
+                "development"
+            ],
+            "repo_url": "https://github.com/smkamranqadri/llamaport",
+            "icon_url": "https://raw.githubusercontent.com/smkamranqadri/llamaport/main/src-tauri/icons/128x128@2x.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/smkamranqadri/llamaport/main/docs/running.png",
+                "https://raw.githubusercontent.com/smkamranqadri/llamaport/main/docs/download.png"
+            ],
+            "official_site": "https://github.com/smkamranqadri/llamaport",
+            "languages": [
+                "rust",
+                "typescript"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Adds [Llamaport](https://github.com/smkamranqadri/llamaport), an open-source macOS GUI for llama.cpp's `llama-server`.

It reads GGUF headers directly so the model list shows real quantisation and context length, shows the full launch command before starting a model, reports live token rates and memory pressure while it serves, and downloads models from Hugging Face with resume that survives a kill.

Rust and Tauri, MIT licensed. Edited `applications.json` rather than the README, per the contribution guidelines, and categorised as `development` to match the other local-LLM tooling in the list.

Unrelated heads-up: `applications.json` already has a trailing comma on line 169 (`"games",`) that makes it invalid strict JSON. It predates this change and I have left it alone, but it may trip a linter on this PR.

Disclosure: I am the author of the app.