### PR TITLE
Add Imark

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -3074,6 +3074,23 @@
             ]
         },
         {
+            "short_description": "Markdown reader that keeps your comments inside the .md file, with a Quick Look extension, live reload, and a skill that lets coding agents open a document for review and wait for your notes. ",
+            "categories": [
+                "markdown"
+            ],
+            "repo_url": "https://github.com/migsilva89/imark",
+            "title": "Imark",
+            "icon_url": "https://raw.githubusercontent.com/migsilva89/imark/main/.github/assets/app-icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/migsilva89/imark/main/.github/assets/imark-window.png",
+                "https://raw.githubusercontent.com/migsilva89/imark/main/.github/assets/imark-comments.png"
+            ],
+            "official_site": "",
+            "languages": [
+                "swift"
+            ]
+        },
+        {
             "short_description": "A modern MacOS markdown editor. ",
             "categories": [
                 "markdown"


### PR DESCRIPTION
Adds [Imark](https://github.com/migsilva89/imark) under `markdown`.

A native macOS Markdown reader. It follows the file while you edit it in another editor, previews `.md` in the Finder through a Quick Look extension, and stores comments inside the document itself as HTML comments, so a note travels with the file and stays invisible in every other renderer.

It also ships a Claude Code / Codex skill: an agent opens a document in the reader and blocks until you press Approve or Request Changes, then reads your margin notes back out of the file. No server, no port, nothing installed on the other side.

Swift, MIT, signed and notarised, macOS 14+.

Only `applications.json` was edited, as the contributing guide asks. Icon and screenshots are hosted in the repo.