### PR TITLE
Add nCompHunt

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,24 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "nCompHunt",
+            "short_description": "Finds and indexes competitive programming rounds, CTFs, hackathons, AI challenges, and design contests in one native menu bar app, with calendar sync and deadline notifications.",
+            "categories": [
+                "productivity",
+                "menubar"
+            ],
+            "repo_url": "https://github.com/nhannht/ncomphunt",
+            "icon_url": "https://raw.githubusercontent.com/nhannht/ncomphunt/master/assets/compyhunt-icon-iOS-Default-1024x1024%401x.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/nhannht/ncomphunt/master/showcase/appstore/as01-hero.png",
+                "https://raw.githubusercontent.com/nhannht/ncomphunt/master/showcase/appstore/as09-dashboard.png"
+            ],
+            "official_site": "https://ncomphunt.nhannht.io.vn",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Adds nCompHunt to `applications.json`.

nCompHunt is a native macOS app that finds and indexes competitions across five kinds in one list: competitive programming rounds, CTFs, hackathons, AI/ML challenges, and design contests. Deadlines surface in a menu bar extra with live countdowns and a desktop widget, and can optionally sync into a dedicated Apple Calendar that reconciles when an organizer moves a date. No account, no server: it talks directly to the public sources and keeps its index in local storage.

Built in Swift 6 / SwiftUI with SwiftData.

- Repo: https://github.com/nhannht/ncomphunt
- Site: https://ncomphunt.nhannht.io.vn
- Mac App Store: https://apps.apple.com/app/id6791654003

Checklist against CONTRIBUTING:

- One pull request for one app
- Edited `applications.json`, not `README.md`
- Searched for duplicates first, no existing entry
- Recent commits, README in English, MIT license
- Description is short and ends with a full stop
- No trailing whitespace, no reformatting of surrounding entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)