### PR TITLE
Add Browser Cookie Bridge

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -8,10 +8,10 @@
                 "menubar",
                 "browser"
             ],
-            "repo_url": "https://github.com/apoorvdarshan/browser-cookie-bridge",
-            "icon_url": "https://raw.githubusercontent.com/apoorvdarshan/browser-cookie-bridge/main/marketing/app-icon.png",
+            "repo_url": "https://github.com/aopv/browser-cookie-bridge",
+            "icon_url": "https://raw.githubusercontent.com/aopv/browser-cookie-bridge/main/marketing/app-icon.png",
             "screenshots": [
-                "https://raw.githubusercontent.com/apoorvdarshan/browser-cookie-bridge/main/marketing/product-hunt/01-overview.png"
+                "https://raw.githubusercontent.com/aopv/browser-cookie-bridge/main/marketing/product-hunt/01-overview.png"
             ],
             "official_site": "https://cookiebridge.apoorvdarshan.com",
             "languages": [

--- a/applications.json
+++ b/applications.json
@@ -8,10 +8,10 @@
                 "menubar",
                 "browser"
             ],
-            "repo_url": "https://github.com/aopv/browser-cookie-bridge",
-            "icon_url": "https://raw.githubusercontent.com/aopv/browser-cookie-bridge/main/marketing/app-icon.png",
+            "repo_url": "https://github.com/apoorvdarshan/browser-cookie-bridge",
+            "icon_url": "https://raw.githubusercontent.com/apoorvdarshan/browser-cookie-bridge/main/marketing/app-icon.png",
             "screenshots": [
-                "https://raw.githubusercontent.com/aopv/browser-cookie-bridge/main/marketing/product-hunt/01-overview.png"
+                "https://raw.githubusercontent.com/apoorvdarshan/browser-cookie-bridge/main/marketing/product-hunt/01-overview.png"
             ],
             "official_site": "https://cookiebridge.apoorvdarshan.com",
             "languages": [

--- a/applications.json
+++ b/applications.json
@@ -1,6 +1,25 @@
 {
     "applications": [
 	{
+            "title": "Browser Cookie Bridge",
+            "short_description": "Transfer signed-in sessions between local Chromium browsers and ChatGPT Codex on macOS.",
+            "categories": [
+                "utilities",
+                "menubar",
+                "browser"
+            ],
+            "repo_url": "https://github.com/apoorvdarshan/browser-cookie-bridge",
+            "icon_url": "https://raw.githubusercontent.com/apoorvdarshan/browser-cookie-bridge/main/marketing/app-icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/apoorvdarshan/browser-cookie-bridge/main/marketing/product-hunt/01-overview.png"
+            ],
+            "official_site": "https://cookiebridge.apoorvdarshan.com",
+            "languages": [
+                "swift",
+                "javascript"
+            ]
+        },
+	{
             "title": "ActivityWatch",
             "short_description": "Open-source automated time tracker that tracks how you spend time on your devices.",
             "categories": [


### PR DESCRIPTION
## Summary

Add Browser Cookie Bridge, an MIT-licensed macOS utility for transferring signed-in sessions between local Chromium browsers and ChatGPT Codex.

The entry includes:

- Utilities, Menubar, and Browser categories
- native app icon and product screenshot
- official website and GitHub repository
- Swift and JavaScript languages

## Eligibility

- confirmed the application and repository URL are not already listed
- searched open and closed pull requests; no prior Browser Cookie Bridge submission exists
- repository is public, actively maintained, and MIT-licensed
- README is clear and written in English

## Validation

- parsed `applications.json` successfully with JSON5
- `git diff --check`
- verified the repository, icon, screenshot, and official-site links return HTTP 200
