### PR TITLE
Add nastro - terminal call recorder with on-device transcription

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,24 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "nastro",
+            "short_description": "Terminal call recorder for macOS that captures system audio and mic (no bot joins the call) and transcribes on-device with speaker diarization, via TUI or headless CLI.",
+            "categories": [
+                "audio",
+                "productivity"
+            ],
+            "repo_url": "https://github.com/scaccogatto/nastro",
+            "icon_url": "",
+            "screenshots": [
+                "https://raw.githubusercontent.com/scaccogatto/nastro/main/.github/demo.gif"
+            ],
+            "official_site": "https://github.com/scaccogatto/nastro",
+            "languages": [
+                "go",
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## What it does

nastro is a terminal call recorder for macOS: it captures system audio and mic simultaneously (no bot joins the call) and transcribes on-device with speaker diarization, usable as a TUI or a headless CLI.

## Why it fits Audio / Productivity

It's an audio-capture and transcription tool aimed at meeting notes, so it fits alongside the other recording/transcription entries in the Audio category, with Productivity as a secondary category for the meeting-notes use case.

Demo: https://github.com/scaccogatto/nastro/blob/main/.github/demo.gif

Disclosure: I'm the author of this project.