### PR TITLE
Add FunNotch

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,25 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "FunNotch",
+            "short_description": "Puts the MacBook notch to work: media controls, a drag-and-drop file shelf, clipboard history, focus sessions that block sites and apps, and twelve configurable widgets.",
+            "categories": [
+                "utilities",
+                "menubar",
+                "productivity"
+            ],
+            "repo_url": "https://github.com/JoshuaT1105/FunNotch",
+            "icon_url": "https://funnotch.xyz/icon-192.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/JoshuaT1105/FunNotch/main/screenshots/open-home.png",
+                "https://raw.githubusercontent.com/JoshuaT1105/FunNotch/main/screenshots/open-focus.png"
+            ],
+            "official_site": "https://funnotch.xyz",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Adds **FunNotch** to `applications.json`, following the format in CONTRIBUTING.md.

FunNotch is a free, open-source macOS app that puts the MacBook notch to work: media controls with a working scrubber, a drag-and-drop file shelf, clipboard history, focus sessions that block websites and whole apps, a HUD that replaces the system volume/brightness overlay, and twelve configurable widgets.

- **Source:** https://github.com/JoshuaT1105/FunNotch
- **Site:** https://funnotch.xyz
- **Licence:** GPL-3.0
- **Language:** Swift / SwiftUI
- **Requirements:** macOS 14+, universal (Apple Silicon and Intel)
- **Categories:** `utilities`, `menubar`, `productivity`

Checked for an existing entry first — there isn't one. Edited `applications.json` rather than `README.md` as the guidelines ask.

*Note for maintainers:* `applications.json` does not currently parse as strict JSON — there is a pre-existing trailing comma in the `categories` array of the "Amazing Tic Tac Toe" entry (around line 170). I have left it alone rather than mixing an unrelated fix into this PR, but happy to send a separate one if that would help.

🤖 Generated with [Claude Code](https://claude.com/claude-code)