### PR TITLE
Add Gibson to the Screensaver category

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1819,6 +1819,24 @@
             ]
         },
         {
+            "short_description": "Screen saver that draws a hacker film dashboard from real system telemetry.",
+            "categories": [
+                "screensaver"
+            ],
+            "repo_url": "https://github.com/PerfectoWeb/Gibson",
+            "title": "Gibson",
+            "icon_url": "",
+            "screenshots": [
+                "https://raw.githubusercontent.com/PerfectoWeb/Gibson/main/docs/images/dashboard-green.png",
+                "https://raw.githubusercontent.com/PerfectoWeb/Gibson/main/docs/images/dashboard-amber.png",
+                "https://raw.githubusercontent.com/PerfectoWeb/Gibson/main/docs/images/portrait.png"
+            ],
+            "official_site": "",
+            "languages": [
+                "swift"
+            ]
+        },
+        {
             "short_description": "The Git interface you've been missing all your life has finally arrived. ",
             "categories": [
                 "git"


### PR DESCRIPTION
## Project URL
https://github.com/PerfectoWeb/Gibson

## Category
screensaver

## Description
Gibson is a macOS screen saver that turns an idle display into the security operations dashboard from every hacker film, except most of the readings are real. It samples the machine it runs on for the process table, CPU load per core, memory pressure, swap, volume capacity, network throughput, load average, uptime and thermal state, and lays them out across seventeen panels on a grid that stretches to any display. Everything else on screen, the globe, the radar, the vault and the account dump, is invented for the look, and the README says line by line which is which. Four colour schemes derived from a single hue each, separate layouts for landscape and portrait, and a privacy switch that masks the host name, user name and addresses so the saver is safe to leave running on a lock screen in an office. Written in Swift against the system frameworks only, with no package manager and no Xcode project: a plain Makefile builds a universal bundle for macOS 14 and newer.

## Why it should be included to `Awesome macOS open source applications ` (optional)
The screensaver category has ten entries and none of them do live system telemetry. Gibson is MIT licensed, has no dependencies, ships a universal binary signed with a Developer ID and notarised by Apple, and documents its architecture and contribution workflow for anyone who wants to add a panel.

## Checklist
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md)
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English