### PR TITLE
Add Codex Quota Overlay

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -17,6 +17,25 @@
             ]
         },
 	{
+            "title": "Codex Quota Overlay",
+            "short_description": "Privacy-friendly quota, reset-time, and reset-credit overlay for Codex Desktop.",
+            "categories": [
+                "development",
+                "productivity",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/cpys/codex-quota-overlay",
+            "icon_url": "https://raw.githubusercontent.com/cpys/codex-quota-overlay/main/site/assets/app-icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/cpys/codex-quota-overlay/main/site/assets/product-preview.png"
+            ],
+            "official_site": "https://cpys.github.io/codex-quota-overlay/",
+            "languages": [
+                "javascript",
+                "swift"
+            ]
+        },
+	{
             "short_description": "Clipboard history manager for macOS with terminal-style navigation, image previews, and cursor-following popup.",
             "categories": [
                 "utilities",


### PR DESCRIPTION
Maintainer submission: I maintain Codex Quota Overlay.

## Project URL
https://github.com/cpys/codex-quota-overlay

## Category
development, productivity, utilities

## Description
Codex Quota Overlay is a privacy-friendly open-source desktop utility for Windows and macOS. It displays Codex quota, reset time, and reset credits beside the active conversation title, and only appears while Codex Desktop is active.

The project has an MIT license, an English README, recent commits, and macOS DMG/ZIP releases for Apple Silicon and Intel Macs.

## Why it should be included
It gives Codex Desktop users an unobtrusive, local-first way to see quota information without repeatedly opening the account menu.

## Checklist
- [x] Edited applications.json instead of README.md
- [x] Only one project/change is in this pull request
- [x] Screenshot added
- [x] Has a commit from less than 2 years ago
- [x] Has a clear README in English