### PR TITLE
Add Vigil

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,24 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "Vigil",
+            "short_description": "Native terminal that runs manager-led trees of coding agents (Claude Code, Codex, OpenCode), with worker results rolling up as summaries while every node keeps its own TUI.",
+            "categories": [
+                "terminal",
+                "development"
+            ],
+            "repo_url": "https://github.com/butterlatte-zhang/vigil",
+            "icon_url": "https://raw.githubusercontent.com/butterlatte-zhang/vigil/main/docs/media/vigil-app-icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/butterlatte-zhang/vigil/main/docs/media/tree-demo.png",
+                "https://raw.githubusercontent.com/butterlatte-zhang/vigil/main/docs/media/history-replay.png"
+            ],
+            "official_site": "https://butterlatte-zhang.github.io/vigil/",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Project URL
https://github.com/butterlatte-zhang/vigil

## Category
terminal, development

## Description
Vigil is a native macOS terminal (Swift + SwiftUI, GPU-accelerated rendering via libghostty, GPL-3.0) for orchestrating coding agents as a tree: a manager agent spawns workers and sub-managers (Claude Code, Codex, and OpenCode can be mixed in one tree), worker results roll back up to the manager as summaries, and every node remains the agent CLI's own native TUI that you can open and drive directly. Finished sessions keep full per-node transcripts for read-only replay and can be resumed in place. Ships as a signed and notarized DMG with Sparkle auto-update.

## Why it should be included to `Awesome macOS open source applications` (optional)
Native (non-Electron) macOS app in an active niche (AI coding-agent orchestration), open source under GPL-3.0, with notarized releases and an English README including a demo video and screenshots.

## Checklist
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)