### PR TITLE
Add DueFlow local-first deadline assistant

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11084,12 +11084,12 @@
             ]
         },
         {
-            "title": "DueFlow",
             "short_description": "Local-first deadline assistant that turns notices and files into actionable schedules, risk checks, and calendar exports.",
             "categories": [
                 "productivity"
             ],
             "repo_url": "https://github.com/Ustinian5/DueFlow",
+            "title": "DueFlow",
             "icon_url": "https://raw.githubusercontent.com/Ustinian5/DueFlow/main/desktop/src-tauri/icons/128x128@2x.png",
             "screenshots": [
                 "https://raw.githubusercontent.com/Ustinian5/DueFlow/main/docs/images/01-dashboard.png"

--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,24 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "DueFlow",
+            "short_description": "Local-first deadline assistant that turns notices and files into actionable schedules, risk checks, and calendar exports.",
+            "categories": [
+                "productivity"
+            ],
+            "repo_url": "https://github.com/Ustinian5/DueFlow",
+            "icon_url": "https://raw.githubusercontent.com/Ustinian5/DueFlow/main/desktop/src-tauri/icons/128x128@2x.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/Ustinian5/DueFlow/main/docs/images/01-dashboard.png"
+            ],
+            "official_site": "https://ustinian5.github.io/DueFlow/",
+            "languages": [
+                "python",
+                "typescript",
+                "rust"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Project URL
https://github.com/Ustinian5/DueFlow

## Category
productivity

## Description
DueFlow is an MIT-licensed, local-first deadline assistant for macOS-capable Tauri desktops. It turns notices, screenshots, files, and text into reviewable tasks, reverse schedules, risk checks, and local calendar exports. Its mock provider supports a deterministic local demo without an API key, and the repository includes Python, React, and Rust verification gates.

## Why it should be included to `Awesome macOS open source applications`

DueFlow is a current open-source productivity application with a clear English README, a public project site, a recent release, a recent commit, and reproducible source-build instructions. The submitted icon, screenshot, repository, and project-site links all return HTTP 200.

## Checklist

- [x] Edit `applications.json` instead of `README.md`.
- [x] Only one project/change is in this pull request.
- [x] Screenshot added.
- [x] Has a commit from less than 2 years ago.
- [x] Has a clear README in English.
