### PR TITLE
Add MetaClean

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,24 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "MetaClean",
+            "short_description": "Offline desktop app for removing metadata from images, Office documents, PDFs, and text files.",
+            "categories": [
+                "security",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/Moresyl/metaclean",
+            "icon_url": "https://raw.githubusercontent.com/Moresyl/metaclean/master/src-tauri/icons/icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/Moresyl/metaclean/master/assets/metaclean-screenshot.png"
+            ],
+            "official_site": "https://github.com/Moresyl/metaclean",
+            "languages": [
+                "typescript",
+                "rust"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Project URL
https://github.com/Moresyl/metaclean

## Category
security, utilities

## Description
MetaClean is a free and open-source cross-platform desktop app that removes metadata from images, Office documents, PDFs, and text files locally. It provides native macOS builds for Apple Silicon and Intel, requires no uploads, and includes no telemetry.

## Why it should be included to Awesome macOS open source applications (optional)
MetaClean gives macOS users an offline graphical privacy utility for inspecting and cleaning sensitive file metadata before sharing files.

## Checklist
- [x] Edit applications.json instead of README.md.
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English