### PR TITLE
Add DSH Studio

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,6 +1,22 @@
 {
     "applications": [
 	{
+            "title": "DSH Studio",
+            "short_description": "Cross-platform desktop host for installing, running, and managing DeepSeek Harness with an embedded web UI.",
+            "categories": [
+                "development",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/Moresyl/dsh-studio",
+            "icon_url": "https://raw.githubusercontent.com/Moresyl/dsh-studio/main/src-tauri/icons/icon.png",
+            "screenshots": [],
+            "official_site": "https://github.com/Moresyl/dsh-studio",
+            "languages": [
+                "rust",
+                "typescript"
+            ]
+        },
+	{
             "title": "ActivityWatch",
             "short_description": "Open-source automated time tracker that tracks how you spend time on your devices.",
             "categories": [


### PR DESCRIPTION
## Project URL
https://github.com/Moresyl/dsh-studio

## Category
development, utilities

## Description
Cross-platform desktop host for installing, running, and managing DeepSeek Harness with an embedded web UI.

## Why it should be included
DSH Studio is open source, has current macOS release artifacts, an English README, and recent commits.

## Checklist
- [x] Edited applications.json instead of README.md
- [x] Only one project/change is in this pull request
- [x] Screenshots added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a clear README in English