### PR TITLE
Add Clipbara

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -35,7 +35,7 @@
             ]
         },
         {
-            "short_description": "Paste-like clipboard manager with pinboards, Quick Look previews, search, and one-click paste.",
+            "short_description": "Paste-like clipboard manager with pinboards, Quick Look previews, search, and one-click copying.",
             "categories": [
                 "menubar",
                 "utilities",

--- a/applications.json
+++ b/applications.json
@@ -43,7 +43,7 @@
             ],
             "repo_url": "https://github.com/mobrava/Clipbara",
             "title": "Clipbara",
-            "icon_url": "https://raw.githubusercontent.com/mobrava/Clipbara/main/PasteClip/Resources/Assets.xcassets/AppIcon.appiconset/256.png",
+            "icon_url": "https://raw.githubusercontent.com/mobrava/Clipbara/main/Clipbara/Resources/Assets.xcassets/AppIcon.appiconset/256.png",
             "screenshots": [
                "https://raw.githubusercontent.com/mobrava/Clipbara/main/docs/assets/pasteclip-demo.gif"
             ],

--- a/applications.json
+++ b/applications.json
@@ -41,13 +41,13 @@
                 "utilities",
                 "productivity"
             ],
-            "repo_url": "https://github.com/minsang-alt/PasteClip",
-            "title": "PasteClip",
-            "icon_url": "https://raw.githubusercontent.com/minsang-alt/PasteClip/main/PasteClip/Resources/Assets.xcassets/AppIcon.appiconset/256.png",
+            "repo_url": "https://github.com/mobrava/Clipbara",
+            "title": "Clipbara",
+            "icon_url": "https://raw.githubusercontent.com/mobrava/Clipbara/main/PasteClip/Resources/Assets.xcassets/AppIcon.appiconset/256.png",
             "screenshots": [
-               "https://raw.githubusercontent.com/minsang-alt/PasteClip/main/docs/assets/pasteclip-demo.gif"
+               "https://raw.githubusercontent.com/mobrava/Clipbara/main/docs/assets/pasteclip-demo.gif"
             ],
-            "official_site": "https://github.com/minsang-alt/PasteClip",
+            "official_site": "https://github.com/mobrava/Clipbara",
             "languages": [
                 "swift"
             ]

--- a/applications.json
+++ b/applications.json
@@ -34,6 +34,24 @@
                 "swift"
             ]
         },
+        {
+            "short_description": "Paste-like clipboard manager with pinboards, Quick Look previews, search, and one-click paste.",
+            "categories": [
+                "menubar",
+                "utilities",
+                "productivity"
+            ],
+            "repo_url": "https://github.com/minsang-alt/PasteClip",
+            "title": "PasteClip",
+            "icon_url": "https://raw.githubusercontent.com/minsang-alt/PasteClip/main/PasteClip/Resources/Assets.xcassets/AppIcon.appiconset/256.png",
+            "screenshots": [
+               "https://raw.githubusercontent.com/minsang-alt/PasteClip/main/docs/assets/pasteclip-demo.gif"
+            ],
+            "official_site": "https://github.com/minsang-alt/PasteClip",
+            "languages": [
+                "swift"
+            ]
+        },
 
 	{
             "title": "VPN Bypass",


### PR DESCRIPTION
## Project URL
https://github.com/mobrava/Clipbara

## Category
menubar, utilities, productivity

## Description
Clipbara (formerly PasteClip — renamed to avoid a name collision with an existing Mac App Store app) is a free, open-source clipboard manager for macOS (GPL-3.0, Swift 6 + SwiftUI). It captures text, rich text, HTML, images, links, files, colors, and code snippets, and shows them in a card-style interface. Features include named Pinboards with drag and drop, Quick Look previews with the Space key, search and filters, one-click copying, per-app exclusions, and a configurable history limit. All data stays local (SwiftData); no accounts, no servers, no telemetry. Notarized by Apple. Requires macOS 14+.

## Checklist
- [x] App is open source and macOS compatible
- [x] Added in alphabetical order (JSON)
- [x] Icon and screenshot URLs are raw links