### PR TITLE
Add Holeberry

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -10,6 +10,7 @@
             "title": "Holeberry",
             "icon_url": "https://raw.githubusercontent.com/pedrovieira/Holeberry/main/Assets/AppIcon.png",
             "screenshots": [
+                "https://raw.githubusercontent.com/pedrovieira/Holeberry/main/Assets/README%20header.png",
                 "https://raw.githubusercontent.com/pedrovieira/Holeberry/main/Assets/max-connections.png",
                 "https://raw.githubusercontent.com/pedrovieira/Holeberry/main/Assets/menu-unblock.png",
                 "https://raw.githubusercontent.com/pedrovieira/Holeberry/main/Assets/browser-unblock.png"

--- a/applications.json
+++ b/applications.json
@@ -1,6 +1,26 @@
 {
     "applications": [
 	{
+            "short_description": "A native and modern macOS menu bar app to monitor and control your Pi-hole instances.",
+            "categories": [
+                "menubar",
+                "security"
+            ],
+            "repo_url": "https://github.com/pedrovieira/Holeberry",
+            "title": "Holeberry",
+            "icon_url": "https://raw.githubusercontent.com/pedrovieira/Holeberry/main/Assets/AppIcon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/pedrovieira/Holeberry/main/Assets/max-connections.png",
+                "https://raw.githubusercontent.com/pedrovieira/Holeberry/main/Assets/menu-unblock.png",
+                "https://raw.githubusercontent.com/pedrovieira/Holeberry/main/Assets/browser-unblock.png"
+            ],
+            "official_site": "https://holeberryapp.com",
+            "languages": [
+                "swift"
+            ]
+        },
+
+	{
             "title": "ActivityWatch",
             "short_description": "Open-source automated time tracker that tracks how you spend time on your devices.",
             "categories": [


### PR DESCRIPTION
## Project URL
https://github.com/pedrovieira/Holeberry

## Category
menubar, security

## Description
Holeberry is a native and modern macOS menu bar app (Swift 6, MIT licensed) that puts your Pi-hole® right in the menu bar — no browser tab required. It shows blocking status and query stats at a glance, lets you disable blocking for a set amount of time or indefinitely (with a countdown timer pill in the menu bar), unblock the domain of your current browser tab (Safari, Chrome/Chromium, Firefox/Zen) with one click, and allowlist or unblock recently-blocked domains. It supports Pi-hole v5 and v6, up to two instances kept in sync with per-server status dots and aggregated stats, and global keyboard shortcuts. Requires macOS 14+.

## Why it should be included to `Awesome macOS open source applications` (optional)
Holeberry is the only actively maintained open-source menu bar app that both monitors **and controls** Pi-hole from macOS — the existing Pi Stats entry is a visualization-only widget, while Holeberry adds one-click control (disable blocking, unblock the current tab, allowlist domains) on top of monitoring. It fits the security category as a network-wide ad-blocking/DNS privacy tool, is fully native (Swift/SwiftUI), MIT licensed, has a clear English README, and an active release history.

## Checklist
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English
