### PR TITLE
Add MacVitals to System and Menubar

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11069,6 +11069,24 @@
             ]
         },
         {
+            "title": "MacVitals",
+            "short_description": "Native macOS menu-bar monitor for temperatures, fans, CPU, memory, network, battery, and disk.",
+            "categories": [
+                "system",
+                "menubar"
+            ],
+            "repo_url": "https://github.com/muneerahm/MacVitals",
+            "icon_url": "https://raw.githubusercontent.com/muneerahm/MacVitals/main/MacVitals/Assets.xcassets/AppIcon.appiconset/icon_512x512.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/muneerahm/MacVitals/main/docs/images/thermals-overview.png",
+                "https://raw.githubusercontent.com/muneerahm/MacVitals/main/docs/images/system-modules.png"
+            ],
+            "official_site": "https://github.com/muneerahm/MacVitals",
+            "languages": [
+                "swift"
+            ]
+        },
+        {
             "title": "MacNTop",
             "short_description": "macOS menu bar system monitor with retro CRT aesthetics.",
             "categories": [


### PR DESCRIPTION
## Project URL
https://github.com/muneerahm/MacVitals

## Category
System, Menubar

## Description
MacVitals is a native, open-source macOS menu-bar monitor for temperatures, fan RPM, CPU, memory, network, battery, and disk. It is read-only, makes no network requests, and includes no telemetry. The current release is source-only and supports macOS 14+.

## Why it should be included
It is a recently maintained MIT-licensed Swift/AppKit/SwiftUI system monitor with a clear English README, verified build instructions, an app icon, and privacy-safe screenshots.

## Checklist
- [x] Edited applications.json instead of README.md
- [x] Only one project/change is in this pull request
- [x] Screenshots added
- [x] Has a commit from less than 2 years ago
- [x] Has a clear README in English

Disclosure: I maintain the submitted project.