### PR TITLE
Add amtrino (menubar, development)

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -4345,6 +4345,23 @@
           ]
         },
         {
+            "short_description": "Live menu bar dots for local AI coding sessions (Claude Code, Codex CLI). ",
+            "categories": [
+                "menubar",
+                "development"
+            ],
+            "repo_url": "https://github.com/arian-shamaei/amtrino",
+            "title": "amtrino",
+            "icon_url": "",
+            "screenshots": [
+                "https://raw.githubusercontent.com/arian-shamaei/amtrino/main/docs/assets/menu.png"
+            ],
+            "official_site": "",
+            "languages": [
+                "swift"
+            ]
+        },
+        {
             "short_description": "macOS menubar status indicator. ",
             "categories": [
                 "menubar"


### PR DESCRIPTION
Adds **[amtrino](https://github.com/arian-shamaei/amtrino)** — live menu bar dots for local AI coding sessions (Claude Code, Codex CLI): one identity-colored dot per session in a 3×3 grid, pulsing while the model responds, flashing when a response finishes; notifications jump to the session's tmux pane. Swift, MIT, notarized releases.

Edited `applications.json` only, textual insert (kept existing formatting untouched), categories `menubar` + `development`, alphabetical placement before AnyBar.

![the amtrino menu](https://raw.githubusercontent.com/arian-shamaei/amtrino/main/docs/assets/menu.png)