### PR TITLE
Add Loadout

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,24 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "Loadout",
+            "short_description": "Inspects and manages the skills, slash commands, subagents, plugins and MCP servers that coding assistants load, with usage counts read from session logs.",
+            "categories": [
+                "development",
+                "other-development"
+            ],
+            "repo_url": "https://github.com/migsilva89/loadout",
+            "icon_url": "https://raw.githubusercontent.com/migsilva89/loadout/main/Resources/Loadout.iconset/icon_256x256.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/migsilva89/loadout/main/.github/assets/loadout-browse.gif",
+                "https://raw.githubusercontent.com/migsilva89/loadout/main/.github/assets/loadout-all.gif"
+            ],
+            "official_site": "https://loadout.migsilva.dev",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Project URL
https://github.com/migsilva89/loadout

## Category
development, other-development

## Description
Loadout is a native macOS 15+ app, written in Swift 6 and SwiftUI, that shows and manages what coding assistants such as Claude Code, Codex and opencode load: skills, slash commands, subagents, plugins and MCP servers. It reads real usage counts from the assistants' session logs and includes an editor for the items you own. MIT licensed and free.

## Why it should be included to `Awesome macOS open source applications ` (optional)
The list has no entry for a tool that inspects the configuration of local coding assistants. Loadout is a native, open source macOS app in that space, with a website and tagged releases.

## Checklist
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English
