### PR TITLE
Add Downright Markdown editor

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -3144,6 +3144,24 @@
             ]
         },
         {
+            "short_description": "Native macOS Markdown reader and editor for ordinary files, with Quick Look, Finder thumbnails, source-preserving rendering, and safe review of external rewrites.",
+            "categories": [
+                "markdown",
+                "editors",
+                "text"
+            ],
+            "repo_url": "https://github.com/ezzy1630/Downright",
+            "title": "Downright",
+            "icon_url": "https://raw.githubusercontent.com/ezzy1630/Downright/cdf426319c54c5dab969409f61e548dbb2312a1d/Resources/AppIcon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/ezzy1630/Downright/cdf426319c54c5dab969409f61e548dbb2312a1d/Docs/downright-renderer-showcase.png"
+            ],
+            "official_site": "https://downright.cc/",
+            "languages": [
+                "swift"
+            ]
+        },
+        {
             "short_description": "Text editor for exact sciences with built-in KaTeX/AsciiMath support. ",
             "categories": [
                 "tex"


### PR DESCRIPTION
Adds Downright to applications.json as a native macOS Markdown reader/editor. It is MIT-licensed, written in Swift, supports ordinary Markdown files, Quick Look, Finder thumbnails, and safe review of external rewrites. Website: https://downright.cc/ Source: https://github.com/ezzy1630/Downright. I maintain Downright and am available for corrections.