### PR TITLE
Add Wandful

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,5 +1,25 @@
 {
     "applications": [
+        {
+            "title": "Wandful",
+            "short_description": "Magic wand for the desktop: summon it from the menu bar, draw a rune with the mouse, and the keyboard shortcut bound to it is cast into the app you were in.",
+            "categories": [
+                "keyboard",
+                "productivity",
+                "menubar"
+            ],
+            "repo_url": "https://github.com/ostapondo/wandful",
+            "icon_url": "https://raw.githubusercontent.com/ostapondo/wandful/main/docs/icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/ostapondo/wandful/main/docs/wand.gif",
+                "https://raw.githubusercontent.com/ostapondo/wandful/main/docs/spellbook.gif"
+            ],
+            "official_site": "https://ostapondo.github.io/wandful/",
+            "languages": [
+                "rust",
+                "typescript"
+            ]
+        },
 	{
             "title": "ActivityWatch",
             "short_description": "Open-source automated time tracker that tracks how you spend time on your devices.",


### PR DESCRIPTION
Adds [Wandful](https://github.com/ostapondo/wandful) — a magic wand for the desktop: summon it from the menu bar (or a hotkey), draw a rune with the mouse, and the keyboard shortcut bound to it is cast into the app you were in. Rust + TypeScript (Tauri 2), MIT, macOS builds on the releases page and via Homebrew (`brew install --cask ostapondo/tap/wandful`).

Follows the applications.json format; categories keyboard / productivity / menubar; icon and screenshots hosted in the repo.