### PR TITLE
Add Abendrot

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,6 +1,22 @@
 {
     "applications": [
 	{
+            "title": "Abendrot",
+            "short_description": "Free open-source Mac screen warmer that cuts nighttime blue light and warms every display around local sunset.",
+            "categories": [
+                "utilities",
+                "menubar",
+                "system"
+            ],
+            "repo_url": "https://github.com/matthewrball/abendrot",
+            "icon_url": "https://raw.githubusercontent.com/matthewrball/abendrot/main/assets/abendrot-icon.png",
+            "screenshots": [],
+            "official_site": "https://abendrot.app",
+            "languages": [
+                "swift"
+            ]
+        },
+	{
             "title": "ActivityWatch",
             "short_description": "Open-source automated time tracker that tracks how you spend time on your devices.",
             "categories": [


### PR DESCRIPTION
## Project URL
https://github.com/matthewrball/abendrot

## Category
utilities, menubar, system

## Description
Abendrot is a free, open-source Mac screen warmer that cuts nighttime blue light. It warms every display around your local sunset so your evenings aren't lit up like daytime. It targets the short-wavelength melanopic light (blue/cyan) that tricks your body clock into thinking it's still daytime.

## Why it should be included to `Awesome macOS open source applications` (optional)
Native Swift menu-bar app, MIT license, recent commits, clear English README. Official site: https://abendrot.app

## Checklist
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English