### PR TITLE
Add Orbly

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,25 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "Orbly",
+            "short_description": "Dictation for macOS. Hold Fn, speak, let go, and the transcript lands at the cursor. Whisper runs on device, no account and no cloud.",
+            "categories": [
+                "audio",
+                "productivity",
+                "menubar"
+            ],
+            "repo_url": "https://github.com/lou1s19/Orbly",
+            "icon_url": "https://raw.githubusercontent.com/lou1s19/Orbly/main/Resources/logo.png",
+            "screenshots": [
+               "https://raw.githubusercontent.com/lou1s19/Orbly/main/Resources/screenshot-overlay.png",
+               "https://raw.githubusercontent.com/lou1s19/Orbly/main/Resources/screenshot-app.png"
+            ],
+            "official_site": "https://orbly-website.vercel.app",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Adds [Orbly](https://github.com/lou1s19/Orbly), an open source dictation app for macOS.

Hold Fn, speak, let go, and the transcript lands at the cursor. Whisper runs on device via bundled whisper.cpp, no account and no cloud. Swift and SwiftUI, AGPL-3.0, signed and notarised, universal binary for macOS 14+.

Edited `applications.json` only, as the contribution guidelines require. Categories: audio, productivity, menubar. Icon and both screenshot URLs return 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)