### PR TITLE
Add DSH Desk Pet

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,6 +1,24 @@
 {
     "applications": [
 	{
+            "title": "DSH Desk Pet",
+            "short_description": "Desktop pet that mirrors your coding agent's state, with skins generated from a photo of your own pet.",
+            "categories": [
+                "productivity",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/anneheartrecord/dsh-desk-pet",
+            "icon_url": "https://raw.githubusercontent.com/anneheartrecord/dsh-desk-pet/main/assets/web/deepseek/idle/00.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/anneheartrecord/dsh-desk-pet/main/docs/media/diy-skin.png",
+                "https://raw.githubusercontent.com/anneheartrecord/dsh-desk-pet/main/docs/media/floats-above.png"
+            ],
+            "official_site": "https://github.com/anneheartrecord/dsh-desk-pet",
+            "languages": [
+                "python"
+            ]
+        },
+	{
             "title": "ActivityWatch",
             "short_description": "Open-source automated time tracker that tracks how you spend time on your devices.",
             "categories": [


### PR DESCRIPTION
Adds [DSH Desk Pet](https://github.com/anneheartrecord/dsh-desk-pet) — a macOS desktop pet that mirrors what your coding agent is doing, and whose skins can be generated from a photo of your own pet.

One entry appended to `applications.json`, nothing else touched. `README.md` left alone per the contributing guidelines.

**What it is.** A real AppKit window on the desktop, not a widget inside a web UI, so it stays above everything you work in — fullscreen Spaces included — and moves through six states as the agent works, waits on a confirmation, finishes, or fails. It ships five skins, and a bundled skill turns one photo into a whole skin (the eighteen poses a skin needs), generated by the user's own image tool on their own credentials.

**Why it might suit this list.** No dependencies at all: it runs on the `/usr/bin/python3` that ships with macOS and talks to AppKit through `ctypes`. No Electron, no node_modules, nothing to compile, and the frame pipeline (PNG decode, chroma key, scale) is standard library, so there is no ffmpeg either. MIT licensed, 268 tests, active commits today.

**One thing to flag before you review.** The repository is bilingual and `README.md` is the Chinese version, with English at [README_EN.md](https://github.com/anneheartrecord/dsh-desk-pet/blob/main/README_EN.md). Your guidelines list a non-English README as grounds for ineligibility, so I want to raise it myself rather than have you find it: the English documentation is complete and maintained in the same commits, it is just in the second file. If having English at `README.md` is a hard requirement I would rather know than have the PR sit — happy to swap them.

**Categories.** `productivity` and `utilities`. It also has an optional menu-bar item, so `menubar` would not be wrong either; I left it out to avoid claiming a category the app is not primarily about.

**Eligibility checklist**

- Searched the existing entries first; no desk-pet or agent-status app is listed
- Individual pull request for a single suggestion
- Edited `applications.json`, not `README.md`
- Description is one sentence and ends with a period
- Recent commits (today), MIT license, builds and runs on current macOS
- macOS only, which is stated on the first screen of both READMEs
