### PR TITLE
Add AI Gist

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,6 +1,24 @@
 {
     "applications": [
 	{
+            "title": "AI Gist",
+            "short_description": "Local-first AI prompt manager with variable filling, Jinja templates, AI generation, and WebDAV/iCloud backup.",
+            "categories": [
+                "productivity",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/yarin-zhang/AI-Gist",
+            "icon_url": "https://raw.githubusercontent.com/yarin-zhang/AI-Gist/main/resources/icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/yarin-zhang/AI-Gist/main/docs/images/image-main.png"
+            ],
+            "official_site": "https://getaigist.com",
+            "languages": [
+                "typescript",
+                "javascript"
+            ]
+        },
+	{
             "title": "ActivityWatch",
             "short_description": "Open-source automated time tracker that tracks how you spend time on your devices.",
             "categories": [


### PR DESCRIPTION
Adds [AI Gist](https://github.com/yarin-zhang/AI-Gist) to applications.json (categories: productivity, utilities).

AI Gist is an open-source (AGPL-3.0), local-first AI prompt manager for macOS — variable filling, Jinja templates, AI-assisted prompt generation (Ollama, LM Studio, OpenAI-compatible APIs), version history, and WebDAV/iCloud backup. All data stays local. Available on the Mac App Store and as a notarized DMG. Actively maintained — latest release 2.1.0, August 2026.