### PR TITLE
Add Plainsay — on-device dictation for macOS

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,25 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "Plainsay",
+            "short_description": "Dictation app that transcribes on-device with Whisper or NVIDIA Parakeet, with an optional cleanup pass using a key you control.",
+            "categories": [
+                "audio",
+                "menubar",
+                "productivity"
+            ],
+            "repo_url": "https://github.com/conrader/plainsay",
+            "icon_url": "https://raw.githubusercontent.com/conrader/plainsay/main/docs/assets/logo.svg",
+            "screenshots": [
+                "https://raw.githubusercontent.com/conrader/plainsay/main/Screenshots/setup-ready.png",
+                "https://raw.githubusercontent.com/conrader/plainsay/main/Screenshots/settings-speech.png"
+            ],
+            "official_site": "https://plainsay.app",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Adds [Plainsay](https://github.com/conrader/plainsay), an MIT-licensed macOS dictation app.

Hold a hotkey, speak, release — the text lands wherever your cursor is. Transcription runs on-device via WhisperKit or NVIDIA Parakeet (Core ML), so audio doesn't leave the machine. An optional cleanup pass turns spoken language into written language using an API key you control.

- Swift/SwiftUI menu-bar app, no account and no subscription required
- Notarized releases and a reproducible WER/latency benchmark are in the repo
- Edited `applications.json` (not `README.md`) per CONTRIBUTING.md, appended at the end of the array to match the convention of recent additions

Categories: `audio`, `menubar`, `productivity`.