### PR TITLE
Add Mac Classic Player

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,25 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "Mac Classic Player",
+            "short_description": "Keyboard-driven media player for macOS, in the spirit of Media Player Classic.",
+            "categories": [
+                "player",
+                "video"
+            ],
+            "repo_url": "https://github.com/piro0919/mac-classic-player",
+            "icon_url": "https://raw.githubusercontent.com/piro0919/mac-classic-player/main/lp/public/icon.png",
+            "screenshots": [
+               "https://raw.githubusercontent.com/piro0919/mac-classic-player/main/lp/public/screenshot-main.png",
+               "https://raw.githubusercontent.com/piro0919/mac-classic-player/main/lp/public/screenshot-shortcuts.png"
+            ],
+            "official_site": "https://mcp.kkweb.io/",
+            "languages": [
+                "rust",
+                "typescript"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Project URL
https://github.com/piro0919/mac-classic-player

## Category
player, video

## Description
Mac Classic Player is a media player for macOS for people who miss how direct Media Player Classic was on Windows. You open a file and it plays — the keyboard does the work, not the menus. Big files stream through a local server with range requests, so a multi-gigabyte video starts right away instead of loading first. It also keeps a recent files list, takes drag and drop, and updates itself from GitHub Releases. Built with Tauri, MIT licensed, free.

## Why it should be included to `Awesome macOS open source applications ` (optional)
There are plenty of good players on the list already, but none of them are going for the Media Player Classic feel, which is honestly the whole reason I built this one.

I'm the author, so take that for what it's worth.

## Checklist
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English