### PR TITLE
Add Grux

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,6 +1,24 @@
 {
     "applications": [
 	{
+            "title": "Grux",
+            "short_description": "Menu bar assistant that reads your active window and reaches local mail, calendar, notes, and files, using your own API key or a local model.",
+            "categories": [
+                "productivity",
+                "utilities",
+                "menubar"
+            ],
+            "repo_url": "https://github.com/dotcomjack/grux",
+            "screenshots": [
+                "https://raw.githubusercontent.com/dotcomjack/grux/main/docs/screenshots/local-models.png",
+                "https://raw.githubusercontent.com/dotcomjack/grux/main/docs/screenshots/integrations.png"
+            ],
+            "official_site": "https://gruxai.com",
+            "languages": [
+                "swift"
+            ]
+        },
+	{
             "title": "ActivityWatch",
             "short_description": "Open-source automated time tracker that tracks how you spend time on your devices.",
             "categories": [


### PR DESCRIPTION
Adds **Grux**, a native macOS menu bar assistant.

It reads the window you are currently in through the Accessibility API, and
reaches the mail, calendar, notes and files already on the machine. It runs
against your own API key, or against a local model through Ollama with no key
at all. No account, no server, no telemetry.

Swift and SwiftUI, MIT licensed, with a signed and notarized build on the
releases page.

- Source: https://github.com/dotcomjack/grux
- Site: https://gruxai.com

Against the contribution guidelines and the eligibility rules:

- [x] Searched first, not a duplicate
- [x] Individual pull request for this one suggestion
- [x] Edited `applications.json`, not `README.md`
- [x] Used the documented entry format, with existing categories only
- [x] Description is short and ends with a full stop
- [x] Builds in current Xcode, Swift 6 toolchain
- [x] Commits are recent, the project is actively maintained
- [x] Has a licence, MIT
- [x] README is clear and written in English
- [x] No trailing whitespace
