### PR TITLE
Add OpenVoiceFlow

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,27 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "OpenVoiceFlow",
+            "short_description": "On-device voice dictation for macOS with local transcription and optional text cleanup.",
+            "categories": [
+                "audio",
+                "productivity",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/shimoverse/openvoiceflow",
+            "icon_url": "https://raw.githubusercontent.com/shimoverse/openvoiceflow/main/docs/assets/openvoiceflow-icon-512.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/shimoverse/openvoiceflow/main/docs/assets/demo-poster.jpg"
+            ],
+            "official_site": "https://openvoiceflow.com",
+            "languages": [
+                "swift",
+                "objective_c",
+                "python",
+                "shell"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Project URL
https://github.com/shimoverse/openvoiceflow

## Category
audio, productivity, utilities

## Description
OpenVoiceFlow is a free, open-source macOS voice-dictation app with on-device transcription and optional text cleanup.

## Why it should be included
It is a maintained, MIT-licensed native macOS application with a public release and English documentation. This is a self-submission from the project maintainer.

## Checklist
- [x] Edited `applications.json` instead of `README.md`
- [x] Only one project/change is in this pull request
- [x] Added an available screenshot
- [x] Has a commit from less than 2 years ago
- [x] Has a clear README in English