### PR TITLE
Add Starcat

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,24 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "short_description": "Native, local-first GitHub Stars manager that turns saved repositories into a searchable, AI-assisted knowledge base.",
+            "categories": [
+                "development",
+                "productivity"
+            ],
+            "repo_url": "https://github.com/starcat-app/Starcat",
+            "title": "Starcat",
+            "icon_url": "https://raw.githubusercontent.com/starcat-app/Starcat/main/Starcat/Resources/Assets.xcassets/AppIcon.appiconset/icon_512x512.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/starcat-app/Starcat/main/main.webp",
+                "https://raw.githubusercontent.com/starcat-app/Starcat/main/screenshots/rag-workbench.webp"
+            ],
+            "official_site": "https://starcat.ink/",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Project URL

https://github.com/starcat-app/Starcat

## Category

development, productivity

## Description

Starcat is a native, local-first GitHub Stars manager for macOS. It turns saved repositories into a searchable knowledge base with tags, private notes, full-text and semantic search, release tracking, repository health signals, and optional AI-assisted summaries and RAG workflows.

The app is built with Swift and SwiftUI, licensed under MIT, and available through its official website, Homebrew tap, and the Mac App Store.

## Why it should be included in Awesome macOS open source applications

Starcat is an actively maintained, open-source macOS application with a clear English README, recent releases, reproducible source builds, an official signed and notarized distribution, and multiple screenshots.

It provides a native and local-first alternative for developers whose GitHub Stars have outgrown the basic bookmark interface.

Disclosure: I am the maintainer of Starcat.

## Checklist

- [x] Edit applications.json instead of README.md
- [x] Only one project/change is in this pull request
- [x] Screenshots added
- [x] Has a commit from less than 2 years ago
- [x] Has a clear README in English