### PR TITLE
Add Pitop Viewer to Images

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -4048,6 +4048,23 @@
             ]
         },
         {
+            "short_description": "Lightweight image & video viewer for macOS with native HEIC and RAW support.",
+            "categories": [
+                "images"
+            ],
+            "repo_url": "https://gitlab.com/christophepicot/pitop-viewer",
+            "title": "Pitop Viewer",
+            "icon_url": "https://viewer.pitop.fr/logo.png",
+            "screenshots": [
+                "https://viewer.pitop.fr/screenshot-main.png"
+            ],
+            "official_site": "https://viewer.pitop.fr",
+            "languages": [
+                "rust",
+                "typescript"
+            ]
+        },
+        {
             "short_description": "macOS menubar app for automating screenshots. ",
             "categories": [
                 "images"


### PR DESCRIPTION
Adds **Pitop Viewer** to the Images category (edited applications.json per CONTRIBUTING).

- Free and open source (GPL-3.0), built with Tauri (Rust + system WebView), ~24 MB.
- Lightweight image & video viewer for macOS with native HEIC and RAW support, video playback and light editing.
- Repo: https://gitlab.com/christophepicot/pitop-viewer
- Site: https://viewer.pitop.fr

Follows the JSON schema; description ends with a period; no trailing whitespace.