### PR TITLE
Add OffPDF

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,24 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "short_description": "An offline PDF toolkit with 23 tools for editing, converting, organizing, OCR, and more.",
+            "categories": [
+                "productivity",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/McanKul/offpdf",
+            "title": "OffPDF",
+            "icon_url": "https://raw.githubusercontent.com/McanKul/offpdf/main/docs/assets/offpdf-mark.svg",
+            "screenshots": [
+                "https://raw.githubusercontent.com/McanKul/offpdf/main/docs/assets/offpdf-home.png"
+            ],
+            "official_site": "https://offpdf.com",
+            "languages": [
+                "typescript",
+                "rust"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Project URL
https://github.com/McanKul/offpdf

## Category
productivity, utilities

## Description
OffPDF is an open-source, offline PDF toolkit for macOS with 23 tools for editing, converting, organizing, OCR, and related document tasks. Files stay on the device.

## Why it should be included to `Awesome macOS open source applications` (optional)
It is actively maintained, MIT-licensed, has a clear English README, and provides a signed and notarized macOS release.

Disclosure: I maintain OffPDF.

## Checklist
- [x] Edit `applications.json` instead of `README.md`.
- [x] Only one project/change is in this pull request.
- [x] Screenshot added.
- [x] Has a commit from less than 2 years ago.
- [x] Has a clear README in English.