### PR TITLE
Add reminal (terminal, utilities)

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,24 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "reminal",
+            "short_description": "Streams every window and terminal to any browser with input; software closed-lid mode keeps the Mac awake headlessly.",
+            "categories": [
+                "terminal",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/harshalgajjar/Reminal",
+            "icon_url": "https://raw.githubusercontent.com/harshalgajjar/Reminal/main/assets/reminal-icon-1024.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/harshalgajjar/Reminal/main/docs/lid.gif"
+            ],
+            "official_site": "https://reminal.app",
+            "languages": [
+                "go",
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Adds [reminal](https://github.com/harshalgajjar/Reminal) — streams every window and terminal on a Mac into any browser (with input), and its software closed-lid mode keeps a MacBook awake and rendering headlessly (virtual display, no dummy HDMI plug). AGPL-3.0, Go + Swift.

- Edited `applications.json` only, per the contribution guidelines
- Categories from `categories.json`: `terminal`, `utilities`
- Not a duplicate (searched existing entries)
- Description ends with a full stop, no trailing whitespace

Disclosure: I'm the author.