### PR TITLE
Add crterm

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -6678,6 +6678,23 @@
             ]
         },
         {
+            "short_description": "Beautifully opinionated terminal emulator, with advanced session navigation and GPU-accelerated retro presets.",
+            "categories": [
+                "terminal"
+            ],
+            "repo_url": "https://github.com/mbcltd/CRTerminal",
+            "title": "crterm",
+            "icon_url": "https://raw.githubusercontent.com/mbcltd/CRTerminal/main/CRTerminal/Assets.xcassets/AppIcon.appiconset/icon_512x512.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/mbcltd/CRTerminal/main/screenshots/light.png",
+                "https://raw.githubusercontent.com/mbcltd/CRTerminal/main/screenshots/vt220.png"
+            ],
+            "official_site": "https://crterm.ai",
+            "languages": [
+                "swift"
+            ]
+        },
+        {
             "short_description": "Terminal built on web technologies.",
             "categories": [
                 "terminal"


### PR DESCRIPTION
## Project URL
https://github.com/mbcltd/CRTerminal

## Category
terminal

## Description
crterm is a beautifully opinionated terminal emulator, with advanced session navigation and GPU-accelerated retro presets. It is a free, open-source (Apache 2.0) native macOS terminal with Metal GPU-accelerated rendering, a ⌘K palette across all sessions, searchable command history, split panes, tear-off windows, and retro CRT presets modelled on historic monitors (including a degauss button). Ships as a signed/notarised DMG with auto-updates. Requires macOS 26 (Tahoe)+, Apple Silicon. Written in Swift.

## Why it should be included to `Awesome macOS open source applications ` (optional)
It fills a niche the terminal category doesn't cover yet — a native, GPU-accelerated terminal with authentic CRT-era looks — and is actively developed with commits this week.

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)