### PR TITLE
Add PuppyOne

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,6 +1,23 @@
 {
     "applications": [
 	{
+            "title": "PuppyOne",
+            "short_description": "A local-first workspace where you and your AI work on the same files.",
+            "categories": [
+                "editors",
+                "productivity"
+            ],
+            "repo_url": "https://github.com/puppyone-ai/puppyone-desktop",
+            "icon_url": "https://www.puppyone.ai/og-image.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/puppyone-ai/puppyone-desktop/main/public/puppyone-overview.png"
+            ],
+            "official_site": "https://www.puppyone.ai",
+            "languages": [
+                "typescript"
+            ]
+        },
+	{
             "title": "ActivityWatch",
             "short_description": "Open-source automated time tracker that tracks how you spend time on your devices.",
             "categories": [


### PR DESCRIPTION
## Project URL
https://github.com/puppyone-ai/puppyone-desktop

## Category
editors, productivity

## Description
PuppyOne — A local-first workspace where you and your AI work on the same files.

Official site: https://www.puppyone.ai

Adds a single entry to applications.json. Checked for duplicates: no existing PuppyOne entry.
