### PR TITLE
Add Soju (free Wine stack for Battle.net/D2R/Steam on Apple Silicon)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3464,7 +3464,7 @@ You can see in which language an app is written. Currently there are following l
   </p>
   </details>
 
-### 🎮 Games (13)
+### 🎮 Games (14)
 - [0 A.D.](https://svn.wildfiregames.com/public/ps/trunk/) - Real-time strategy game of ancient warfare
 
   **Languages:** <img src='./icons/cpp-64.png' alt='C++ icon' title='C++' height='16'/> C++ 
@@ -3585,6 +3585,10 @@ You can see in which language an app is written. Currently there are following l
 
   </p>
   </details>
+
+- [Soju](https://github.com/BCD1210/soju) - Run Battle.net, Diablo II: Resurrected and Steam games on Apple Silicon Macs with a fully free Wine stack built from GPL sources; one-line installer.
+
+  **Languages:** <img src='./icons/shell-64.png' alt='Shell icon' title='Shell' height='16'/> Shell 
 
 - [Stockfish](https://github.com/daylen/stockfish-mac) - Beautiful, powerful chess application.
 


### PR DESCRIPTION
Adds [Soju](https://github.com/BCD1210/soju) to the Games section.

Soju runs Battle.net, Diablo II: Resurrected and Steam games on Apple Silicon Macs using a fully free Wine stack: the engine is built from CodeWeavers' published GPL sources by the repo's scripts, with a one-line installer and a prebuilt engine release. GPL-3.0, shell scripts + docs, no proprietary redistribution.

Entry follows the existing format (alphabetical within Games, shell language icon), and the section count was bumped 13 → 14.