### PR TITLE
Add noswoosh

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -8947,6 +8947,23 @@
             ]
         },
         {
+            "short_description": "Instant, animation-free switching between macOS Spaces with a 3-finger swipe or Ctrl+arrow keys.",
+            "categories": [
+                "window-management",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/mmathys/noswoosh",
+            "title": "noswoosh",
+            "icon_url": "https://raw.githubusercontent.com/mmathys/noswoosh/main/assets/icon-rounded.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/mmathys/noswoosh/main/assets/demo.gif"
+            ],
+            "official_site": "",
+            "languages": [
+                "swift"
+            ]
+        },
+        {
             "short_description": "Menu bar app for your calendar meetings",
             "categories": [
                 "utilities",


### PR DESCRIPTION
Adds [noswoosh](https://github.com/mmathys/noswoosh) — instant, animation-free switching between macOS Spaces with a 3-finger swipe or Ctrl+arrow keys. Written in Swift (one file), MIT-licensed, signed + notarized releases, installable via Homebrew cask.

Per the contribution guidelines: edited `applications.json` only, categories from `categories.json` (window-management, utilities), description ends with a period.

Disclosure: I'm the author.