### PR TITLE
Add Markout

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -3144,6 +3144,24 @@
             ]
         },
         {
+            "short_description": "Native Markdown editor with live preview, offline KaTeX math, Mermaid diagrams, and HTML/PDF export.",
+            "categories": [
+                "markdown",
+                "editors",
+                "text"
+            ],
+            "repo_url": "https://github.com/maxmilian/markout",
+            "title": "Markout",
+            "icon_url": "https://raw.githubusercontent.com/maxmilian/markout/main/Resources/Assets.xcassets/AppIcon.appiconset/icon_256.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/maxmilian/markout/main/assets/screenshot.png"
+            ],
+            "official_site": "https://github.com/maxmilian/markout",
+            "languages": [
+                "swift"
+            ]
+        },
+        {
             "short_description": "Text editor for exact sciences with built-in KaTeX/AsciiMath support. ",
             "categories": [
                 "tex"


### PR DESCRIPTION
## Project URL
https://github.com/maxmilian/markout

## Category
markdown, editors, text

## Description
Markout is a modern, native macOS Markdown editor for Apple Silicon, built with SwiftUI + TextKit + WKWebView — a spiritual successor to the unmaintained MacDown. It offers a split editor with live GitHub-Flavored Markdown preview, syntax highlighting with switchable editor and preview themes, TeX math (KaTeX), Mermaid diagrams, editor to preview scroll sync, find & replace, automatic list continuation, image paste/drop, a table of contents generator, and export to standalone HTML or PDF. All rendering engines are vendored, so the preview works completely offline with no network access.

## Why it should be included to `Awesome macOS open source applications ` (optional)
MacDown, the long-standing open-source Markdown editor on this list, has been unmaintained for years. Markout fills the same niche with a native SwiftUI/AppKit implementation for macOS 14+, is MIT licensed, actively developed, and installable via Homebrew (`brew install --cask maxmilian/tap/markout`).

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
