### PR TITLE
Add Freeflow

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,6 +1,25 @@
 {
     "applications": [
 	{
+            "title": "Freeflow",
+            "short_description": "Voice dictation with screen context you point at — hold \u2318 to record, circle to capture, local Parakeet transcription.",
+            "categories": [
+                "productivity",
+                "utilities",
+                "menubar"
+            ],
+            "repo_url": "https://github.com/jayamitkatariya/Freeflow",
+            "icon_url": "https://raw.githubusercontent.com/jayamitkatariya/Freeflow/main/docs/assets/freeflow-icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/jayamitkatariya/Freeflow/main/docs/assets/freeflow-demo.gif",
+                "https://raw.githubusercontent.com/jayamitkatariya/Freeflow/main/docs/assets/freeflow-settings-overview.png"
+            ],
+            "official_site": "https://github.com/jayamitkatariya/Freeflow",
+            "languages": [
+                "swift"
+            ]
+        },
+	{
             "title": "ActivityWatch",
             "short_description": "Open-source automated time tracker that tracks how you spend time on your devices.",
             "categories": [


### PR DESCRIPTION
Add Freeflow — voice dictation with screen context you point at. macOS menu-bar app, local Parakeet transcription (FluidAudio), circle-to-capture via ScreenCaptureKit, glass UI, BYOK AI polish. Fits Productivity / Utilities / Menubar. https://github.com/jayamitkatariya/Freeflow