### PR TITLE
Add apple-mail-mcp

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -7426,6 +7426,21 @@
             ]
         },
         {
+            "short_description": "Fast access to Apple Mail from the command line and AI clients (MCP). Sub-millisecond full-text search using Mail's own SQLite index, verified sends, reviewed bulk triage.",
+            "categories": [
+                "mail",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/parasxos/apple-mail-mcp",
+            "title": "apple-mail-mcp",
+            "icon_url": "https://raw.githubusercontent.com/parasxos/apple-mail-mcp/main/docs/assets/logo.png",
+            "screenshots": [],
+            "official_site": "https://pypi.org/project/apple-mailbox-mcp/",
+            "languages": [
+                "python"
+            ]
+        },
+        {
             "short_description": "Datamosh your videos on macOS. ",
             "categories": [
                 "video"


### PR DESCRIPTION
Adds apple-mail-mcp (MIT, Python): command-line and AI (MCP) access to Apple Mail. Reads Mail's own SQLite Envelope Index for sub-millisecond full-text search, verifies every send by reading back the Sent copy, and supports reviewed bulk triage. Installable via Homebrew tap or PyPI (apple-mailbox-mcp). macOS only, fully local.