### PR TITLE
Add WinKeys

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,20 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "short_description": "Windows keyboard shortcuts that work on macOS, for people who just switched.",
+            "categories": [
+                "keyboard"
+            ],
+            "repo_url": "https://github.com/neural-beat/winkeys",
+            "title": "WinKeys",
+            "icon_url": "",
+            "screenshots": [],
+            "official_site": "",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Adds [WinKeys](https://github.com/neural-beat/winkeys), a menu bar app that
translates Windows keyboard habits into their macOS equivalents: `Ctrl+C`,
`Ctrl+V`, `Ctrl+Z` and the rest, plus `Home`/`End` going to the start and end of
the line rather than the document.

Karabiner and Karabiner-Elements are already listed and remain the right tool for
keyboard customisation in general. WinKeys is narrower: it targets people who
just moved from Windows, works with one switch and no configuration, and
deliberately stays out of terminals, editors with an embedded terminal, virtual
machines and remote sessions, where `Ctrl` already means something else.

GPL-3.0, Swift, universal binary (Intel and Apple Silicon), macOS 10.13+.

Per the contribution guidelines: edited `applications.json` rather than the
README, one suggestion in this pull request, and the description ends with a
period. Category `keyboard`, appended at the end of the file as the most recent
entries are.