### PR TITLE
Add Unbury

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,6 +1,23 @@
 {
     "applications": [
 	{
+            "short_description": "Searches your saved browser bookmarks by meaning rather than by title, using a one-line description it writes for each link.",
+            "categories": [
+                "productivity",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/migsilva89/unbury",
+            "title": "Unbury",
+            "icon_url": "https://raw.githubusercontent.com/migsilva89/unbury/main/.github/assets/app-icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/migsilva89/unbury/main/.github/assets/unbury-search.png"
+            ],
+            "official_site": "https://unbury.migsilva.dev",
+            "languages": [
+                "swift"
+            ]
+        },
+	{
             "title": "ActivityWatch",
             "short_description": "Open-source automated time tracker that tracks how you spend time on your devices.",
             "categories": [


### PR DESCRIPTION
Adds Unbury to applications.json under the productivity and utilities categories.

Unbury searches the bookmarks already in your browser by meaning rather than by title, using a one-line description it writes for each link. Swift 6, MIT, macOS 14+ on Apple Silicon.

Source: https://github.com/migsilva89/unbury
Site: https://unbury.migsilva.dev

Only applications.json is touched, per the contribution guidelines. Icon and screenshot URLs resolve.

Disclosure: I am the developer of Unbury.