### PR TITLE
Add Whisk (clipboard manager)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5819,7 +5819,7 @@ You can see in which language an app is written. Currently there are following l
   </p>
   </details>
 
-### ⏱️ Productivity (78)
+### ⏱️ Productivity (79)
 - [ActivityWatch](https://github.com/ActivityWatch/activitywatch) - Open-source automated time tracker that tracks how you spend time on your devices.
 
   **Languages:** <img src='./icons/python-64.png' alt='Python icon' title='Python' height='16'/> Python <img src='./icons/typescript-64.png' alt='TypeScript icon' title='TypeScript' height='16'/> TypeScript 
@@ -6733,6 +6733,19 @@ You can see in which language an app is written. Currently there are following l
   <p>
 
   <img src='https://raw.githubusercontent.com/1000ch/whale/master/demo.png' width='400' loading='lazy' decoding='async' fetchpriority='low'/>
+
+  </p>
+  </details>
+
+- [Whisk](https://github.com/nathan-poncet/whisk) - Keyboard-first clipboard manager with a Liquid Glass panel, filters by app and content type, and rich previews. 
+
+  **Languages:** <img src='./icons/swift-64.png' alt='Swift icon' title='Swift' height='16'/> Swift 
+
+  <details>
+  <summary>Screenshots</summary>
+  <p>
+
+  <img src='https://raw.githubusercontent.com/nathan-poncet/whisk/main/docs/media/screenshot.png' width='400' loading='lazy' decoding='async' fetchpriority='low'/>
 
   </p>
   </details>


### PR DESCRIPTION
## Project URL
https://github.com/nathan-poncet/whisk

## Category
productivity, menubar

## Description
[Whisk](https://github.com/nathan-poncet/whisk) is an open-source (GPL-3.0) clipboard manager for macOS 14+, written in Swift/SwiftUI. It is a menu bar app with a Paste-style panel (Liquid Glass on macOS 26), pins, search operators (`app:`, `type:`, `pinned`), a paste stack, "paste as…" rewrites, rich link/file/image previews, per-app exclusions, local SQLite storage and an English/French interface. It ships as a notarized DMG and a Homebrew cask (`brew install --cask nathan-poncet/tap/whisk`); latest release v0.11.0 (2026-09-19), actively developed.

Website: https://nathan-poncet.github.io/whisk/

Disclosure: I am the author of Whisk.

## Why it should be included to `Awesome macOS open source applications ` (optional)
A native, actively maintained, GPL-3.0 clipboard manager with a Paste-style panel, keyboard-first navigation, rebindable shortcuts and a documented Clean Architecture codebase with a TDD test suite.

*Updated: this PR now edits `applications.json` only, as the contribution guidelines require (the first version edited `README.md`).*

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
