### PR TITLE
Add OPC Company — visual AI-agent company for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -6240,6 +6240,12 @@ You can see in which language an app is written. Currently there are following l
   </p>
   </details>
 
+- [OPC Company](https://github.com/B1ueMu3ic4m/OPCCompany) - Watch your AI coding agents run a 2D company: a CTO agent orchestrates goals into task graphs, AI employees (Claude Code / Codex / Gemini CLI / OpenAI-compatible APIs) work in real terminal seats, risky actions stop at approval gates. Local-first, bilingual (EN/中文), MIT.
+
+  **Languages:** <img src='./icons/swift-64.png' alt='Swift icon' title='Swift' height='16'/> Swift 
+
+  **Website:** [https://github.com/B1ueMu3ic4m/OPCCompany](https://github.com/B1ueMu3ic4m/OPCCompany)
+
 - [OmniPrompt](https://github.com/nsmet/omniprompt-gpt-mac-app) - Your ultimate GPT companion for seamless access on your Mac
 
   **Languages:** <img src='./icons/swift-64.png' alt='Swift icon' title='Swift' height='16'/> Swift 


### PR DESCRIPTION
Adds **OPC Company** to the Applications list (alphabetical, before OmniPrompt).

Open-source (MIT) native macOS app: a CTO agent orchestrates AI coding agents (Claude Code / Codex / Gemini CLI / OpenAI-compatible APIs) as employees in a 2D SpriteKit office, with approval gates and delivery pipelines. Local-first, bilingual (EN/中文), Swift 6.

- Repo: https://github.com/B1ueMu3ic4m/OPCCompany