### PR TITLE
Add MacYT

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,5 +1,21 @@
 {
     "applications": [
+        {
+            "title": "MacYT",
+            "short_description": "Native macOS app for downloading video and audio from any URL with format selection and SponsorBlock integration.",
+            "categories": [
+                "downloader",
+                "utilities",
+                "video"
+            ],
+            "repo_url": "https://github.com/sameerbajaj/MacYT",
+            "icon_url": "https://sameerbajaj.com/assets/images/tools/macyt-icon.webp",
+            "screenshots": [],
+            "official_site": "https://sameerbajaj.com/tools/macyt",
+            "languages": [
+                "swift"
+            ]
+        },
 	{
             "title": "ActivityWatch",
             "short_description": "Open-source automated time tracker that tracks how you spend time on your devices.",


### PR DESCRIPTION
## Project URL
https://github.com/sameerbajaj/MacYT

## Category
downloader, utilities, video

## Description
MacYT is a native macOS SwiftUI frontend for yt-dlp to download video and audio from any URL with format selection, quality controls, and SponsorBlock integration.

## Why it should be included to `Awesome macOS open source applications`
It provides a clean, open-source native Mac interface for yt-dlp without telemetry or ads.

## Checklist
- [x] Edit applications.json instead of README.md.
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English