### PR TITLE
Fix two trailing commas that make applications.json invalid JSON

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -166,7 +166,7 @@
         {
             "short_description": "Fun Tic Tac Toe game equipped with multiplayer (local and online) and leveled single player available on the App Store.",
             "categories": [
-                "games",
+                "games"
             ],
             "repo_url": "https://github.com/Aries-Sciences-LLC/Tic-Tac-Toe",
             "title": "Amazing Tic Tac Toe",
@@ -184,7 +184,7 @@
         {
             "short_description": "Simple and elegant menubar weather app on the App Store.",
             "categories": [
-                "menubar",
+                "menubar"
             ],
             "repo_url": "https://github.com/Aries-Sciences-LLC/Quick-Weather",
             "title": "Quick Weather",


### PR DESCRIPTION
`applications.json` on master currently fails to parse:

```
$ python3 -m json.tool applications.json
Expecting value: line 170 column 13 (char 7085)
```

The cause is two trailing commas, one in the `categories` array of "Amazing Tic Tac Toe" (line 169) and one in "Quick Weather" (line 187). This PR removes both; with them gone the full file (689 apps) parses cleanly. No entries are added, removed, or otherwise changed.

The same fix appears bundled inside #1230 along with an app addition. Filing it standalone so the data file can be unbroken without waiting on an app review, per the one-change-per-PR guideline. Happy to close this one if #1230 merges first.
