### PR TITLE
Add Candela - protects displays from OLED burn-in and wear

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,23 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "Candela",
+            "short_description": "Protects your displays from OLED burn-in and wear: panel health history, a checkup for defects, and the everyday brightness, volume, and scaling controls macOS leaves out.",
+            "categories": [
+                "menubar",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/Rydersel/Candela",
+            "icon_url": "https://raw.githubusercontent.com/Rydersel/Candela/main/.github/assets/icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/Rydersel/Candela/main/.github/assets/hero.webp"
+            ],
+            "official_site": "https://candela.fyi",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Project URL
https://github.com/Rydersel/Candela

## Category
menubar, utilities

## Description
Candela is a macOS menu bar app that protects external displays: adaptive, real-time burn-in defense that eases down bright, unchanged regions while live content stays at full brightness, a panel health history with an exposure heat map, a guided checkup for defects and wear on any display, and everyday control of brightness, volume, and contrast over DDC/CI, plus HiDPI scaling and virtual displays. Native Swift/SwiftUI, macOS 14+, MIT licensed, completely free with no paid tier. All panel data stays on the machine.

## Why it should be included to `Awesome macOS open source applications` (optional)
The list already carries display apps that adjust settings in the moment (MonitorControl). Candela covers the other half: it cares about what happens to the panel over the years you own it, and does the settings too. Actively maintained, notarized Developer ID builds, and the hardware findings behind it are documented in the repo.

Note: the appended entry is valid JSON on its own; the file's existing syntax error near line 170 is addressed separately in #1322 and is left untouched here per the one-change-per-PR rule.

## Checklist
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English
