### PR TITLE
Add Conduck

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,23 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "short_description": "Native voice and text client for your self-hosted or BYO-key AI, with a menu bar companion, global hotkey and Screenshot & Ask. Same conversation on iPhone, iPad, Apple Watch and CarPlay.",
+            "categories": [
+                "chat",
+                "menubar"
+            ],
+            "repo_url": "https://github.com/GigaDuckAI/conduck",
+            "title": "Conduck",
+            "icon_url": "https://conduck.com/conduck-icon-256.png",
+            "screenshots": [
+                "https://conduck.com/media/conduck-film-poster-v1.jpg"
+            ],
+            "official_site": "https://conduck.com/",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Project URL
https://github.com/GigaDuckAI/conduck

## Category
chat, menubar

## Description
Conduck is a native Swift/SwiftUI client for a self-hosted or BYO-key AI: OpenAI-compatible servers such as Ollama and LM Studio, OpenRouter, or agent gateways. On the Mac it is a full app plus a menu bar companion with a global hotkey and Screenshot & Ask; the same conversation continues on iPhone, iPad, Apple Watch and CarPlay through private iCloud. No account, no analytics, no intermediary server. Free on the Mac App Store, Apache-2.0.

## Why it should be included to `Awesome macOS open source applications ` (optional)
One of few fully native (no Electron) open-source AI clients for macOS, and the only one spanning Watch and CarPlay.

## Checklist
- [x] Edit applications.json instead of README.md.
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)