### PR TITLE
Add NoMicSwitch

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,22 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "NoMicSwitch",
+            "short_description": "Pins the default audio input to the Mac's built-in microphone and locks the input volume, so AirPods never take it over.",
+            "categories": [
+                "audio"
+            ],
+            "repo_url": "https://github.com/marks-zyz/NoMicSwitch",
+            "icon_url": "https://raw.githubusercontent.com/marks-zyz/NoMicSwitch/main/assets/icon-512.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/marks-zyz/NoMicSwitch/main/assets/install-terminal.png"
+            ],
+            "official_site": "https://github.com/marks-zyz/NoMicSwitch",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Adds NoMicSwitch to the Audio category.

NoMicSwitch is a headless macOS daemon that pins the default audio input to the Mac's built-in microphone and locks the input volume, so AirPods, iPhone Continuity or a conferencing app cannot take the microphone over. It is written in Swift on top of CoreAudio and is fully event driven, so it uses no CPU while idle and restores the input in under 100 ms.

- Repo: https://github.com/marks-zyz/NoMicSwitch
- License: Unlicense (public domain)
- Language: Swift
- Install: `brew install marks-zyz/tap/nomicswitch`, or a dependency free one line installer

Icon and screenshot URLs are included in the entry as required by CONTRIBUTING.md.