### PR TITLE
Add Higgs

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -35,6 +35,24 @@
             ]
         },
 
+        {
+            "title": "Higgs",
+            "short_description": "Dashboard and chat app for the Higgs inference server: runs MLX models on Apple Silicon behind OpenAI- and Anthropic-compatible APIs, routes to remote providers, and traces every request.",
+            "categories": [
+                "development"
+            ],
+            "repo_url": "https://github.com/panbanda/higgs",
+            "icon_url": "https://raw.githubusercontent.com/panbanda/higgs/main/apps/desktop/src-tauri/icons/128x128.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/panbanda/higgs/main/docs/images/desktop-overview.png",
+                "https://raw.githubusercontent.com/panbanda/higgs/main/docs/images/desktop-chat.png"
+            ],
+            "official_site": "https://github.com/panbanda/higgs",
+            "languages": [
+                "rust",
+                "typescript"
+            ]
+        },
 	{
             "title": "VPN Bypass",
             "short_description": "Route specific domains and services around your corporate VPN while keeping the rest of your traffic protected.",


### PR DESCRIPTION
## Project URL
https://github.com/panbanda/higgs

## Category
development

## Description
Higgs is a dashboard and chat app for the Higgs inference server. The server runs MLX models on Apple Silicon behind OpenAI- and Anthropic-compatible APIs and routes to remote providers; the app shows models, requests, latency and throughput, edits the server config, browses and downloads Hugging Face models, and traces every chat request. Rust and TypeScript (Tauri), MIT licensed, installs with Homebrew.

## Why it should be included to `Awesome macOS open source applications ` (optional)
It is a native macOS app built specifically for Apple Silicon and bundles the CLI, so it works without a separate install.

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English