### PR TITLE
Add MangoDisk

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,6 +1,25 @@
 {
     "applications": [
 	{
+            "short_description": "Safety-first disk cleaner and space analyzer with local scanning and review before deletion.",
+            "categories": [
+                "system",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/harry0703/MangoDisk",
+            "title": "MangoDisk",
+            "icon_url": "https://raw.githubusercontent.com/harry0703/MangoDisk/main/src-tauri/icons/icon.png",
+            "screenshots": [
+                "https://assets.mangodisk.app/images/screenshots/en/light-01-deep-cleanup.jpg",
+                "https://assets.mangodisk.app/images/screenshots/en/light-05-disk-space-analysis.jpg"
+            ],
+            "official_site": "https://mangodisk.app/",
+            "languages": [
+                "rust",
+                "typescript"
+            ]
+        },
+	{
             "title": "ActivityWatch",
             "short_description": "Open-source automated time tracker that tracks how you spend time on your devices.",
             "categories": [


### PR DESCRIPTION
## Project URL

https://github.com/harry0703/MangoDisk

## Category

system, utilities

## Description

MangoDisk is a free and open-source disk cleaner and space analyzer for macOS and Windows. It scans locally, shows file paths and sizes before deletion, and includes deep cleanup, large and duplicate file discovery, app uninstall with leftover detection, startup management, system optimization, and maintenance tools.

## Why it should be included to `Awesome macOS open source applications` (optional)

MangoDisk is actively maintained, has a clear English README, ships signed macOS releases, and currently has more than 2,000 GitHub stars. The entry includes a project icon and two current light-mode screenshots.

## Checklist

- [x] Edited `applications.json` instead of `README.md`.
- [x] Only one project/change is in this pull request.
- [x] Screenshots added.
- [x] Has a commit from less than 2 years ago.
- [x] Has a clear README in English.
