### PR TITLE
Add FilesNest

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -166,7 +166,7 @@
         {
             "short_description": "Fun Tic Tac Toe game equipped with multiplayer (local and online) and leveled single player available on the App Store.",
             "categories": [
-                "games",
+                "games"
             ],
             "repo_url": "https://github.com/Aries-Sciences-LLC/Tic-Tac-Toe",
             "title": "Amazing Tic Tac Toe",
@@ -184,7 +184,7 @@
         {
             "short_description": "Simple and elegant menubar weather app on the App Store.",
             "categories": [
-                "menubar",
+                "menubar"
             ],
             "repo_url": "https://github.com/Aries-Sciences-LLC/Quick-Weather",
             "title": "Quick Weather",
@@ -395,6 +395,24 @@
             "official_site": "https://www.borgbase.com/",
             "languages": [
                 "python"
+            ]
+        },
+        {
+            "short_description": "One-way, resumable sync of macOS Photos libraries to self-hosted or local storage.",
+            "categories": [
+                "backup"
+            ],
+            "repo_url": "https://github.com/moontechs/files-nest",
+            "title": "FilesNest",
+            "icon_url": "https://raw.githubusercontent.com/moontechs/files-nest/main/apple/macos/FilesNest/FilesNest/Assets.xcassets/AppIcon.appiconset/AppIcon-512.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/moontechs/files-nest/main/imgs/menubar-sync-status.png",
+                "https://raw.githubusercontent.com/moontechs/files-nest/main/imgs/settings-server.png"
+            ],
+            "official_site": "",
+            "languages": [
+                "swift",
+                "go"
             ]
         },
         {


### PR DESCRIPTION
## Project URL
https://github.com/moontechs/files-nest

## Category
backup

## Description
FilesNest provides one-way, resumable synchronization of macOS Photos libraries to self-hosted or local storage.

<img width="700" height="850" alt="menubar-sync-status" src="https://github.com/user-attachments/assets/251b4fdd-3090-420c-a4a8-0d32f7a0f897" />
<img width="776" height="549" alt="settings-local-folder" src="https://github.com/user-attachments/assets/3df13e17-374e-4504-86d9-13e77e00f9ff" />
<img width="778" height="584" alt="settings-server" src="https://github.com/user-attachments/assets/ea3ddd37-7b66-4f10-864e-5e80b9852afa" />


## Why it should be included to `Awesome macOS open source applications`
FilesNest is an open-source macOS backup and synchronization application with a self-hosted server option.

## Checklist
- [x] Edit `applications.json` instead of `README.md`.
- [x] Only one project/change is in this pull request.
- [x] Screenshots added.
- [x] Has a commit from less than 2 years ago.
- [x] Has a clear README in English.