### PR TITLE
Add Superagent

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,21 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "title": "Superagent",
+            "short_description": "Desktop app that gives coding agents like Claude Code and Codex a real browser to drive, an iOS Simulator to install and screenshot apps in, and a phone companion app for remote monitoring.",
+            "categories": [
+                "development"
+            ],
+            "repo_url": "https://github.com/pungme/superagent-desktop",
+            "icon_url": "https://raw.githubusercontent.com/pungme/superagent-desktop/main/app/build/icon.png",
+            "screenshots": [],
+            "official_site": "https://superagent.computer",
+            "languages": [
+                "typescript",
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Project URL
https://github.com/pungme/superagent-desktop

## Category
development

## Description
Superagent is an open-source (MIT) macOS desktop app that gives coding agents like Claude Code and Codex a real browser to drive, an iOS Simulator to install and screenshot apps in, and a phone companion app + relay for remote monitoring of a session.

## Why it should be included to `Awesome macOS open source applications` (optional)
It's a real, actively developed macOS app (Electron + SwiftUI + Cloudflare Worker relay), MIT licensed, fits the Development category.

## Checklist
- [x] Edit applications.json instead of README.md.
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
