### PR TITLE
docs(browser): add Dao Browser

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11082,6 +11082,23 @@
             "languages": [
                 "swift"
             ]
+        },
+        {
+            "short_description": "An open-source Chromium-based, Arc-like browser for macOS with a content-first UI, BYOK AI, and MCP support.",
+            "categories": [
+                "browser"
+            ],
+            "repo_url": "https://github.com/msgbyte/dao-browser",
+            "title": "Dao Browser",
+            "icon_url": "https://raw.githubusercontent.com/msgbyte/dao-browser/main/branding/product_logo_256.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/msgbyte/dao-browser/main/docs/preview.png"
+            ],
+            "official_site": "https://dao.msgbyte.com",
+            "languages": [
+                "cpp",
+                "typescript"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Project URL
https://github.com/msgbyte/dao-browser

## Category
browser

## Description
Dao Browser is an open-source Chromium-based, Arc-like browser for macOS. It keeps the UI minimal to leave more room for web content, while adding BYOK AI, MCP, mini windows, and enhanced picture-in-picture.

## Why it should be included to `Awesome macOS open source applications ` (optional)
I have used Dao as my daily browser for several months and iterated on it through more than 100 versions. I would appreciate feedback from more macOS users.

## Checklist
- [X] Edit applications.json instead of README.md.
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a clear README in English
