### PR TITLE
Add Read Assist with UI screenshots

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,5 +1,18 @@
 {
     "applications": [
+        {
+            "title": "Read Assist",
+            "short_description": "Native reading companion for contextual word meanings and passage explanations using your own OpenAI API key.",
+            "categories": ["productivity", "menubar"],
+            "repo_url": "https://github.com/ai-nuke/read-assist",
+            "icon_url": "",
+            "screenshots": [
+                "https://raw.githubusercontent.com/ai-nuke/read-assist/93a09dadf3d8318201c2d362817ea5ea1eff5f0d/dist/verification/ui-word.png",
+                "https://raw.githubusercontent.com/ai-nuke/read-assist/93a09dadf3d8318201c2d362817ea5ea1eff5f0d/dist/verification/ui-passage.png"
+            ],
+            "official_site": "https://github.com/ai-nuke/read-assist",
+            "languages": ["swift"]
+        },
 	{
             "title": "ActivityWatch",
             "short_description": "Open-source automated time tracker that tracks how you spend time on your devices.",


### PR DESCRIPTION
## Project URL

https://github.com/ai-nuke/read-assist

## Category

productivity, menubar

## Description

Read Assist is a native SwiftUI/AppKit reading companion for selected-word meanings and passage explanations. Users supply their own OpenAI API key; provider usage is billed separately. This adds one entry to applications.json, including two screenshots pinned to a source commit.

Affiliation: submitted by the Read Assist repository owner with AI assistance. The current v0.5.0 release supports source builds on macOS 14+ Apple silicon; it does not ship a notarized app binary. Local release build and 43 automated tests passed. Reader compatibility and live API behavior require manual testing.

## Checklist

- [x] Edited applications.json only; README is generated upstream.
- [x] One project in this pull request.
- [x] Two UI screenshots included.
- [x] Recent commits and tagged release.
- [x] Clear README in English and Apache-2.0 source license.
- [x] Added entry parses as JSON, categories exist, and the repository URL appears once as repo_url.

Validation note: strict parsing of the full applications.json fails on the unchanged upstream baseline (including a trailing comma in Amazing Tic Tac Toe's categories). This PR leaves existing entries unchanged and validates the added object separately.
