### PR TITLE
Add Audiout

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,6 +1,25 @@
 {
     "applications": [
-	{
+			{
+		    "short_description": "Menu-bar audio mixer that lets you stream audio to any AirPlay, Bluetooth, or Chromecast device in sync from your Mac. Control app routing and volume individually and create preset scenes.",
+		    "categories": [
+		        "audio",
+		        "menubar",
+		        "utilities"
+		    ],
+		    "repo_url": "https://github.com/aa-hh/Audiout",
+		    "title": "Audiout",
+		    "icon_url": "https://raw.githubusercontent.com/aa-hh/Audiout/main/docs/media/audiout-mark.png",
+		    "screenshots": [
+		        "https://raw.githubusercontent.com/aa-hh/Audiout/main/docs/media/popover-dark.png",
+		        "https://raw.githubusercontent.com/aa-hh/Audiout/main/docs/media/popover-light.png"
+		    ],
+		    "official_site": "https://audiout.app/?s=awesome-oss-mac",
+		    "languages": [
+		        "swift"
+		    ]
+		}
+		{
             "title": "ActivityWatch",
             "short_description": "Open-source automated time tracker that tracks how you spend time on your devices.",
             "categories": [


### PR DESCRIPTION
Adds Audiout, a menu-bar mixer for Mac audio: it sends everything the Mac plays to AirPlay 2, AirPlay 1, Bluetooth, and Chromecast speakers at once, in sync, with per-room faders and per-app routing.

Disclosure: I'm the author. The source is GPL-2.0; a signed, notarized build is sold on the official site. Actively developed, released September 2026.

<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/aa-hh/Audiout

## Category
audio, menubar, utilities

## Description
Only Apple's Music and TV apps can play to every room from a Mac. Audiout does it for whatever your Mac is playing: Spotify, a browser, a game. It lives in the menu bar and puts AirPlay 2, AirPlay 1, Bluetooth, and Chromecast speakers on one mixer, in sync, with a fader per room and a Main Audio fader over everything.

Route each app to its own speaker at its own volume. Save a set of speakers as a scene and bring it back with one click. Shape each speaker with a ten-band EQ, and use the guided delay alignment to fix a speaker that lags behind.

€30 one time, no subscription. One licence covers all your Macs, with free updates for version 1. The app is signed and notarized; the source is public on GitHub under GPL-2.0. Requires Apple Silicon and macOS 14.4 or later.

## Screenshots 
<img width="699" height="761" alt="Screenshot 2026-09-05 at 10 46 32" src="https://github.com/user-attachments/assets/580ea290-1c7f-41b3-b24f-0f8a9221b170" />

<img width="672" height="757" alt="Screenshot 2026-09-05 at 10 57 08" src="https://github.com/user-attachments/assets/921aa2eb-e1bc-401c-bcf2-cd0763302e14" />
 
## Why it should be included to `Awesome macOS open source applications ` (optional)
Lots of time was spent trying to take a tool that has been done before, but make it an enjoyable experience with Nice UI, intuitive UX and A solid set of features.

## Checklist

- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English
