### PR TITLE
Add Loadstone — native Mac window snapper

### DIFF
--- a/.loadstone-pr-note
+++ b/.loadstone-pr-note
@@ -1,0 +1,1 @@
+Loadstone entry pending in applications.json

--- a/.loadstone-pr-note
+++ b/.loadstone-pr-note
@@ -1,1 +1,0 @@
-Loadstone entry pending in applications.json

--- a/applications.json
+++ b/applications.json
@@ -1,6 +1,26 @@
 {
     "applications": [
         {
+            "title": "Loadstone",
+            "short_description": "Native menu-bar window manager that snaps windows to halves, corners, and thirds.",
+            "categories": [
+                "window-management",
+                "menubar",
+                "utilities",
+                "productivity"
+            ],
+            "repo_url": "https://github.com/mortenbrudvik/loadstone",
+            "icon_url": "https://raw.githubusercontent.com/mortenbrudvik/loadstone/main/Loadstone/Assets.xcassets/AppIcon.appiconset/icon_256.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/mortenbrudvik/loadstone/main/docs/layouts.svg",
+                "https://raw.githubusercontent.com/mortenbrudvik/loadstone/main/docs/snap-zones.svg"
+            ],
+            "official_site": "https://github.com/mortenbrudvik/loadstone",
+            "languages": [
+                "Swift"
+            ]
+        },
+        {
             "title": "ActivityWatch",
             "short_description": "Open-source automated time tracker that tracks how you spend time on your devices.",
             "categories": [
@@ -3507,7 +3527,7 @@
             ]
         },
         {
-            "short_description": "The DOS game emulator that’s fit for your Mac.",
+            "short_description": "The DOS game emulator that\u2019s fit for your Mac.",
             "categories": [
                 "games"
             ],
@@ -3837,7 +3857,7 @@
             ]
         },
         {
-            "short_description": "CodeEdit App for macOS – Elevate your code editing experience. Open source, free forever.",
+            "short_description": "CodeEdit App for macOS \u2013 Elevate your code editing experience. Open source, free forever.",
             "categories": [
                 "ide",
                 "editors"
@@ -4299,7 +4319,7 @@
             ]
         },
         {
-            "short_description": "💌 A beautiful, fast and maintained fork of @nylas Mail by one of the original authors",
+            "short_description": "\ud83d\udc8c A beautiful, fast and maintained fork of @nylas Mail by one of the original authors",
             "categories": [
                 "mail"
             ],
@@ -5804,7 +5824,7 @@
             ]
         },
         {
-            "short_description": "macOS app to block your own access to distracting websites etc for a predetermined period of time. It can not be undone by the app or by a restart – you must wait for the timer to run out. ",
+            "short_description": "macOS app to block your own access to distracting websites etc for a predetermined period of time. It can not be undone by the app or by a restart \u2013 you must wait for the timer to run out. ",
             "categories": [
                 "productivity"
             ],
@@ -7312,7 +7332,7 @@
                 "utilities"
             ],
             "repo_url": "https://github.com/felixhageloh/uebersicht",
-            "title": "Übersicht",
+            "title": "\u00dcbersicht",
             "icon_url": "",
             "screenshots": [],
             "official_site": "",
@@ -7349,7 +7369,7 @@
             ]
         },
         {
-            "short_description": "Wireshark is the world’s foremost and widely-used network protocol analyzer. It lets you see what’s happening on your network at a microscopic level and is the de facto (and often de jure) standard across many commercial and non-profit enterprises, government agencies, and educational institutions. ",
+            "short_description": "Wireshark is the world\u2019s foremost and widely-used network protocol analyzer. It lets you see what\u2019s happening on your network at a microscopic level and is the de facto (and often de jure) standard across many commercial and non-profit enterprises, government agencies, and educational institutions. ",
             "categories": [
                 "utilities"
             ],
@@ -8203,7 +8223,7 @@
             ]
         },
         {
-            "short_description": "💻 Medis is a beautiful, easy-to-use Mac database management application for Redis.",
+            "short_description": "\ud83d\udcbb Medis is a beautiful, easy-to-use Mac database management application for Redis.",
             "categories": [
                 "database"
             ],
@@ -9357,7 +9377,7 @@
             ]
         },
         {
-            "short_description": "Cross-platform open source database management tool for Redis ®",
+            "short_description": "Cross-platform open source database management tool for Redis \u00ae",
             "categories": [
                 "database"
             ],
@@ -9500,7 +9520,7 @@
                 "utilities"
             ],
             "repo_url": "https://github.com/relikd/barss",
-            "title": "baRSS – Menu Bar RSS Reader",
+            "title": "baRSS \u2013 Menu Bar RSS Reader",
             "icon_url": "https://raw.githubusercontent.com/relikd/baRSS/main/baRSS/Artwork/application-icon.svg",
             "screenshots": [
                 "https://raw.githubusercontent.com/relikd/baRSS/main/screenshot.png"
@@ -9564,7 +9584,7 @@
             ]
         },
         {
-            "short_description": "🧾 Your daily journal app, diary or anything else to unclutter your mind. Let linked help you get focused by writing down what is in your mind on a daily basis. ",
+            "short_description": "\ud83e\uddfe Your daily journal app, diary or anything else to unclutter your mind. Let linked help you get focused by writing down what is in your mind on a daily basis. ",
             "categories": [
                 "productivity",
                 "notes",
@@ -9900,7 +9920,7 @@
             ]
         },
         {
-            "short_description": "🏈 Cache CocoaPods for faster rebuild and indexing Xcode project.",
+            "short_description": "\ud83c\udfc8 Cache CocoaPods for faster rebuild and indexing Xcode project.",
             "categories": [
                 "utilities"
             ],
@@ -10198,7 +10218,7 @@
         },
         {
             "title": "M-Courtyard",
-            "short_description": "Desktop app for fine-tuning LLMs on Apple Silicon Macs with zero code. Import documents, generate training datasets with AI, LoRA fine-tune, test, and export to Ollama — entirely offline.",
+            "short_description": "Desktop app for fine-tuning LLMs on Apple Silicon Macs with zero code. Import documents, generate training datasets with AI, LoRA fine-tune, test, and export to Ollama \u2014 entirely offline.",
             "categories": [
                 "development"
             ],
@@ -10316,7 +10336,7 @@
             ]
         },
         {
-            "short_description": "Wireshark is the world’s foremost and widely-used network protocol analyzer. It lets you see what’s happening on your network at a microscopic level and is the de facto (and often de jure) standard across many commercial and non-profit enterprises, government agencies, and educational institutions.",
+            "short_description": "Wireshark is the world\u2019s foremost and widely-used network protocol analyzer. It lets you see what\u2019s happening on your network at a microscopic level and is the de facto (and often de jure) standard across many commercial and non-profit enterprises, government agencies, and educational institutions.",
             "categories": [
                 "system"
             ],
@@ -10349,7 +10369,7 @@
             ]
         },
         {
-            "short_description": "Widelands is a free, open source real-time strategy game with singleplayer campaigns and a multiplayer mode. The game was inspired by Settlers II™ (© Bluebyte) but has significantly more variety and depth to it.",
+            "short_description": "Widelands is a free, open source real-time strategy game with singleplayer campaigns and a multiplayer mode. The game was inspired by Settlers II\u2122 (\u00a9 Bluebyte) but has significantly more variety and depth to it.",
             "categories": [
                 "games"
             ],
@@ -10446,7 +10466,7 @@
             ]
         },
         {
-            "short_description": "MacOS menu bar app for launching iOS  and Android 🤖 emulators.",
+            "short_description": "MacOS menu bar app for launching iOS \uf8ff and Android \ud83e\udd16 emulators.",
             "categories": [
                 "menubar"
             ],


### PR DESCRIPTION
## Summary
Adds [Loadstone](https://github.com/mortenbrudvik/loadstone) to the list.

**Loadstone** is a free, MIT-licensed native macOS menu-bar window manager written in Swift. It snaps windows to halves, corners, and thirds.

- Repo: https://github.com/mortenbrudvik/loadstone
- License: MIT
- Language: Swift
- Categories: window-management, menubar, utilities, productivity

## Checklist
- [x] Open source (MIT)
- [x] Native Mac app
- [x] Entry added to `applications.json`