### PR TITLE
Add Lyrimuse

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -873,6 +873,27 @@
             ]
         },
         {
+            "short_description": "Word-synced desktop lyrics for Apple Music, Spotify, QQ Music, NetEase Cloud Music, Kugou and YouTube Music / Spotify Web in the browser, with translation, romanization and Last.fm scrobbling.",
+            "categories": [
+                "audio",
+                "music",
+                "menubar"
+            ],
+            "repo_url": "https://github.com/Yudaotor/lyrimuse",
+            "title": "Lyrimuse",
+            "icon_url": "https://raw.githubusercontent.com/Yudaotor/lyrimuse/main/docs/images/app-icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/Yudaotor/lyrimuse/main/docs/images/app-desktop-lyrics.png",
+                "https://raw.githubusercontent.com/Yudaotor/lyrimuse/main/docs/images/app-dynamic-island.png",
+                "https://raw.githubusercontent.com/Yudaotor/lyrimuse/main/docs/images/app-lyrics-window.png"
+            ],
+            "official_site": "https://yudaotor.github.io/lyrimuse/",
+            "languages": [
+                "swift",
+                "go"
+            ]
+        },
+        {
             "short_description": "Simple yet powerful audio player for BSD/Linux/macOS. ",
             "categories": [
                 "audio"


### PR DESCRIPTION
## Project URL
https://github.com/Yudaotor/lyrimuse

## Category
audio, music, menubar

## Description
Lyrimuse shows real-time, word-by-word synced desktop lyrics on macOS for Apple Music, Spotify, QQ Music, NetEase Cloud Music and Kugou — and for YouTube Music / Spotify Web playing in a browser, synced to the page's own progress. It resolves lyrics from 8 sources and scores every candidate to pick the best match, with on-device translation, romanization (pinyin, Cantonese Jyutping, furigana), and Last.fm / ListenBrainz scrobbling with local listening stats. Swift (app) + Go (background collector), GPL-3.0.

## Why it should be included to `Awesome macOS open source applications ` (optional)
Actively maintained (latest release v1.5.0, September 2026). Fills a gap left by LyricsX (no release since April 2022), including native support for the Chinese streaming players and for web players running in a browser.

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
