### PR TITLE
Add MacOSCleaner utility to applications.json

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11311,6 +11311,24 @@
                 "swift",
                 "rust"
             ]
+         },
+		{
+            "title": "MacOSCleaner",
+            "short_description": "Free macOS utility for cleaning caches, temporary files, application leftovers, duplicates, and other unnecessary data.",
+            "categories": [
+                "utilities",
+                "system"
+            ],
+            "repo_url": "https://github.com/AlexTkDev/MacOSCleaner",
+            "icon_url": "https://raw.githubusercontent.com/AlexTkDev/MacOSCleaner/release/.github/logo.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/AlexTkDev/MacOSCleaner/release/assets/screenshots/Dashboard_v2_1.png",
+                "https://raw.githubusercontent.com/AlexTkDev/MacOSCleaner/release/assets/screenshots/Uninstaller_v2_1.png"
+            ],
+            "official_site": "https://alextkdev.github.io/MacOSCleaner/",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Add MacOSCleaner to the list of open-source macOS applications.

## Project URL
https://github.com/AlexTkDev/MacOSCleaner

## Category
utilities, system

## Description
MacOSCleaner is a free macOS utility for cleaning caches, temporary files, application leftovers, duplicates, and other unnecessary data. It also provides disk analysis, app uninstallation, process management, startup service management, and automation through Siri and Shortcuts.

## Why it should be included to `Awesome macOS open source applications`
MacOSCleaner is an actively maintained native macOS application built with Swift and SwiftUI, focused on system cleanup, disk management, and macOS maintenance.

## Checklist
- [X] Edit https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json instead of https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md.
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English