### PR TITLE
Add AngerRate

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -17,6 +17,24 @@
             ]
         },
         {
+            "title": "AngerRate",
+            "short_description": "Menu bar flame that reflects rising anger signals while you work with Codex or Claude and reminds you to pause.",
+            "categories": [
+                "menubar",
+                "productivity",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/boxyhn/anger-rate",
+            "icon_url": "https://raw.githubusercontent.com/boxyhn/anger-rate/main/assets/app-icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/boxyhn/anger-rate/main/docs/panel-preview-en.png"
+            ],
+            "official_site": "https://github.com/boxyhn/anger-rate",
+            "languages": [
+                "swift"
+            ]
+        },
+        {
             "short_description": "Clipboard history manager for macOS with terminal-style navigation, image previews, and cursor-following popup.",
             "categories": [
                 "utilities",


### PR DESCRIPTION
## Project URL
https://github.com/boxyhn/anger-rate

## Category
menubar, productivity, utilities

## Description
AngerRate is a native macOS menu bar app whose animated flame reflects rising anger signals while someone works with Codex or Claude, offering a small cue to pause and cool down. It is written in Swift, licensed under MIT, supports English and Korean, and keeps analysis local.

## Why it should be included
It is a small open-source menu bar utility with a distinct visual approach to awareness during AI-assisted coding.

Disclosure: I am the maker of AngerRate. The current v0.1.0 download is a public preview; it is ad-hoc signed and has not been Apple-notarized yet. The repository includes source and local build instructions.

## Checklist
- [x] Edited `applications.json` instead of `README.md`.
- [x] Only one project/change is in this pull request.
- [x] Screenshot added.
- [x] Has a commit from less than 2 years ago.
- [x] Has a clear README in English.
