### PR TITLE
Add Gojo

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11311,6 +11311,25 @@
                 "swift",
                 "rust"
             ]
+        },
+        {
+            "title": "Gojo",
+            "short_description": "Native macOS notch workspace for local dictation, window snapping, clipboard history, files, media, and display controls.",
+            "categories": [
+                "productivity",
+                "utilities",
+                "menubar",
+                "window-management"
+            ],
+            "repo_url": "https://github.com/rohoswagger/gojo",
+            "icon_url": "https://raw.githubusercontent.com/rohoswagger/gojo/main/design/logo/gojo-icon-1024.png",
+            "screenshots": [
+                "https://trygojo.com/screenshots/windows.png"
+            ],
+            "official_site": "https://trygojo.com/",
+            "languages": [
+                "swift"
+            ]
         }
     ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/rohoswagger/gojo

## Category
productivity, utilities, menubar, window-management

## Description
Native macOS notch workspace for local dictation, window snapping, clipboard history, files, media, and display controls.

## Why it should be included to `Awesome macOS open source applications ` (optional)
Gojo is an actively maintained Swift macOS utility with a clear English README, GPLv3 source, and public release, official site, icon, and screenshot links.

This submission is made on the maintainer's behalf with their authorization.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [X] Only one project/change is in this pull request
- [X] Screenshots(s) added if any
- [X] Has a commit from less than 2 years ago
- [X] Has a **clear** README in English
