### PR TITLE
Add PR Cockpit

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -11311,6 +11311,23 @@
                 "swift",
                 "rust"
             ]
+        },
+        {
+            "title": "PR Cockpit",
+            "short_description": "An extremely fast GitHub for reviewing pull requests: PRs open in about 20 ms. Keyboard-first, with a CLI for coding agents.",
+            "categories": [
+                "development",
+                "git"
+            ],
+            "repo_url": "https://github.com/theolundqvist/pr-cockpit",
+            "icon_url": "https://raw.githubusercontent.com/theolundqvist/pr-cockpit/main/assets/icon.png",
+            "screenshots": [
+                "https://raw.githubusercontent.com/theolundqvist/pr-cockpit/main/docs/screenshots/landing-inbox.png"
+            ],
+            "official_site": "https://prcockpit.com",
+            "languages": [
+                "TypeScript"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Project URL
https://github.com/theolundqvist/pr-cockpit

## Category
development, git

## Description
PR Cockpit is an extremely fast GitHub for reviewing pull requests: a PR opens in about 20 ms where github.com takes about 1.4 s (p50, [docs/BENCHMARKS.md](https://github.com/theolundqvist/pr-cockpit/blob/main/docs/BENCHMARKS.md)), it is keyboard-first, and it ships a CLI that coding agents use to read PRs and wait for changes.

It fits the `development` and `git` categories alongside the other Git and GitHub clients already in the list, and it is MIT licensed with a clear English README and screenshots.

Repo: https://github.com/theolundqvist/pr-cockpit — site: https://prcockpit.com

## Why it should be included to `Awesome macOS open source applications ` (optional)
It is an open source, actively developed macOS review client for pull requests, a niche the list currently only covers with notification and issue-tracker style apps.

## Checklist
- [x] Edit [applications.json](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/applications.json) instead of [README.md](https://github.com/serhii-londar/open-source-mac-os-apps/blob/master/README.md).
- [x] Only one project/change is in this pull request
- [x] Screenshots(s) added if any
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
