### PR TITLE
Add Headroom notch quota tracker (PeytonNowlin)

### DIFF
--- a/applications.json
+++ b/applications.json
@@ -1,6 +1,24 @@
 {
     "applications": [
         {
+            "title": "Headroom",
+            "short_description": "Tracks Claude, Codex, Grok, and Cursor quotas with tiny LED-style gauges beside the MacBook notch.",
+            "categories": [
+                "development",
+                "menubar",
+                "utilities"
+            ],
+            "repo_url": "https://github.com/PeytonNowlin/Headroom",
+            "icon_url": "",
+            "screenshots": [
+                "https://github.com/PeytonNowlin/Headroom/releases/download/v0.4.1/expanded-saved.png"
+            ],
+            "official_site": "https://github.com/PeytonNowlin/Headroom",
+            "languages": [
+                "swift"
+            ]
+        },
+        {
             "title": "ActivityWatch",
             "short_description": "Open-source automated time tracker that tracks how you spend time on your devices.",
             "categories": [


### PR DESCRIPTION
## Project URL

https://github.com/PeytonNowlin/Headroom

## Category

development, menubar, utilities

## Description

Headroom shows remaining Claude, Codex, Grok, and Cursor quotas as tiny LED-style gauges beside the MacBook notch. It is free, MIT-licensed, and written in Swift/SwiftUI, with downloadable releases for macOS 26+ on Apple silicon. I'm the project author.

This is a separate project from `patwalls/headroom` in #1153; this entry links to `PeytonNowlin/Headroom`.

## Checklist

- [x] Edited `applications.json`, not the generated README.
- [x] One project added; existing entries preserved.
- [x] Included a native component capture using synthetic demo data.
- [x] Has a commit from less than two years ago.
- [x] Has a clear English README and an MIT license.
- [x] Validated JSON, category IDs, and absence of a duplicate repository URL.

Native quota components rendered with synthetic demo data (solid capture background, not a live desktop screenshot):

![Headroom native quota components with demo data](https://github.com/PeytonNowlin/Headroom/releases/download/v0.4.1/expanded-saved.png)
